### PR TITLE
feat: globe projection with toggle

### DIFF
--- a/src/components/flight-tracker.tsx
+++ b/src/components/flight-tracker.tsx
@@ -228,7 +228,7 @@ function FlightTrackerInner() {
 
   return (
     <main className="relative h-screen w-screen overflow-hidden bg-black">
-      <Map mapStyle={mapStyle.style}>
+      <Map mapStyle={mapStyle.style} globeView={settings.globeView}>
         <CameraController city={activeCity} />
         <FlightLayers
           flights={flights}

--- a/src/components/map/map.tsx
+++ b/src/components/map/map.tsx
@@ -34,6 +34,7 @@ type MapProps = {
   children?: ReactNode;
   className?: string;
   mapStyle?: MapStyleSpec;
+  globeView?: boolean;
   center?: [number, number];
   zoom?: number;
   pitch?: number;
@@ -49,11 +50,12 @@ export const Map = forwardRef<MapRef, MapProps>(function Map(
     children,
     className,
     mapStyle = DEFAULT_STYLE.style,
+    globeView = true,
     center = [0, 20],
     zoom = 2.5,
     pitch = 49,
     bearing = -20,
-    minZoom = 2,
+    minZoom = 0,
     maxZoom = 16,
   },
   ref,
@@ -91,6 +93,12 @@ export const Map = forwardRef<MapRef, MapProps>(function Map(
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    if (!mapInstance || !isLoaded) return;
+    const type = globeView ? "globe" : "mercator";
+    (mapInstance as unknown as { setProjection: (opts: { type: string }) => void }).setProjection({ type });
+  }, [mapInstance, isLoaded, globeView]);
 
   useEffect(() => {
     if (!mapInstance || !isLoaded) return;

--- a/src/components/ui/control-panel.tsx
+++ b/src/components/ui/control-panel.tsx
@@ -17,6 +17,7 @@ import {
   Palette,
   ArrowLeftRight,
   Github,
+  Globe,
 } from "lucide-react";
 import { CITIES, type City } from "@/lib/cities";
 import { MAP_STYLES, type MapStyle } from "@/lib/map-styles";
@@ -593,6 +594,16 @@ function SettingsContent() {
             />
           </>
         )}
+
+        <div className="mx-3 my-2 h-px bg-white/4" />
+
+        <SettingRow
+          icon={<Globe className="h-4 w-4" />}
+          title="Globe view"
+          description="Display the Earth as a 3D sphere"
+          checked={settings.globeView}
+          onChange={(v) => update("globeView", v)}
+        />
 
         <div className="mx-3 my-2 h-px bg-white/4" />
 

--- a/src/hooks/use-settings.tsx
+++ b/src/hooks/use-settings.tsx
@@ -20,6 +20,7 @@ export type Settings = {
   showTrails: boolean;
   showShadows: boolean;
   showAltitudeColors: boolean;
+  globeView: boolean;
 };
 
 const DEFAULT_SETTINGS: Settings = {
@@ -29,10 +30,11 @@ const DEFAULT_SETTINGS: Settings = {
   showTrails: true,
   showShadows: true,
   showAltitudeColors: true,
+  globeView: true,
 };
 
 const STORAGE_KEY = "aeris:settings";
-const STORAGE_VERSION = 1;
+const STORAGE_VERSION = 2;
 const WRITE_DEBOUNCE_MS = 300;
 
 type StorageEnvelope = {
@@ -51,7 +53,8 @@ function isValidSettings(obj: unknown): obj is Settings {
       s.orbitDirection === "counter-clockwise") &&
     typeof s.showTrails === "boolean" &&
     typeof s.showShadows === "boolean" &&
-    typeof s.showAltitudeColors === "boolean"
+    typeof s.showAltitudeColors === "boolean" &&
+    typeof s.globeView === "boolean"
   );
 }
 


### PR DESCRIPTION
## Globe Projection

Renders the Earth as a 3D sphere using MapLibre GL v5's native globe projection.

### Changes

- **`use-settings.tsx`** — Added `globeView: boolean` (default `true`), bumped `STORAGE_VERSION` to 2 with migration
- **`map.tsx`** — New `globeView` prop; calls `setProjection({ type: 'globe' | 'mercator' })` reactively; lowered `minZoom` to 0 for full zoom-out
- **`control-panel.tsx`** — Globe toggle in Settings panel (Globe icon from Lucide)
- **`flight-tracker.tsx`** — Passes `settings.globeView` to `<Map>`
- **deck.gl layers** — No changes needed (v9.1+ auto-adapts to globe via MapboxOverlay)

### Notes

- Globe is enabled by default for new users
- Existing users get it via settings migration (merges salvageable keys with new defaults)
- Toggle persists to localStorage