### PR TITLE
Make unit system configurable

### DIFF
--- a/src/components/ui/airport-board.tsx
+++ b/src/components/ui/airport-board.tsx
@@ -10,7 +10,9 @@ import {
   ArrowDown,
   ArrowUp,
 } from "lucide-react";
+import { useSettings } from "@/hooks/use-settings";
 import type { BoardFlight, AirportBoardData } from "@/hooks/use-airport-board";
+import { formatVerticalSpeedValue } from "@/lib/unit-formatters";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -92,12 +94,19 @@ function statusStyle(status: string): {
 // ── Vertical rate ──────────────────────────────────────────────────────
 
 function VRate({ rate }: { rate: number | null }) {
+  const { settings } = useSettings();
   if (rate === null || !Number.isFinite(rate)) {
     return <span className="text-xs text-foreground/15">—</span>;
   }
 
-  const fpm = Math.round(rate * 196.85);
-  if (Math.abs(fpm) < 100) {
+  const vSpeed = formatVerticalSpeedValue(rate, settings.unitSystem);
+  if (vSpeed.value === null) {
+    return <span className="text-xs text-foreground/15">—</span>;
+  }
+
+  const isMetric = settings.unitSystem === "metric";
+  const levelThreshold = isMetric ? 0.5 : 100;
+  if (Math.abs(vSpeed.value) < levelThreshold) {
     return (
       <span className="inline-flex items-center gap-0.5 text-xs text-foreground/20">
         <span className="inline-block h-px w-3 bg-foreground/15" />
@@ -105,7 +114,7 @@ function VRate({ rate }: { rate: number | null }) {
     );
   }
 
-  const isDown = fpm < 0;
+  const isDown = vSpeed.value < 0;
   return (
     <span
       className={`inline-flex items-center gap-0.5 font-mono text-xs tabular-nums ${
@@ -117,7 +126,7 @@ function VRate({ rate }: { rate: number | null }) {
       ) : (
         <ArrowUp className="h-3 w-3" />
       )}
-      <span>{Math.abs(fpm).toLocaleString()}</span>
+      <span>{Math.abs(vSpeed.value).toLocaleString()}</span>
     </span>
   );
 }

--- a/src/components/ui/airport-info-card.tsx
+++ b/src/components/ui/airport-info-card.tsx
@@ -16,6 +16,14 @@ import {
 import type { Airport } from "@/lib/airports";
 import { findNearbyAtcFeeds, iataToIcao } from "@/lib/atc-lookup";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { useSettings } from "@/hooks/use-settings";
+import {
+  formatCloudBaseHundredsFeet,
+  formatPressureHpa,
+  formatTemperatureC,
+  formatVisibility,
+  formatWindFromKnots,
+} from "@/lib/unit-formatters";
 
 type MetarData = {
   rawOb?: string;
@@ -67,13 +75,6 @@ function decodeFltCat(cat: string | undefined): {
   }
 }
 
-function formatVisibility(vis: number | string | undefined): string {
-  if (vis === undefined || vis === null) return "—";
-  if (typeof vis === "string") return vis;
-  if (vis >= 9999) return "10+ SM";
-  return `${vis} SM`;
-}
-
 function cloudCoverLabel(cover: string): string {
   switch (cover.toUpperCase()) {
     case "SKC":
@@ -100,6 +101,7 @@ const METAR_CACHE_TTL_MS = 10 * 60 * 1000;
 const metarCache = new Map<string, { data: MetarData; fetchedAt: number }>();
 
 export function AirportInfoCard({ airport, onClose }: AirportInfoCardProps) {
+  const { settings } = useSettings();
   const [metar, setMetar] = useState<MetarData | null>(null);
   const [metarLoading, setMetarLoading] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
@@ -258,9 +260,12 @@ export function AirportInfoCard({ airport, onClose }: AirportInfoCardProps) {
                       icon={<Wind className="h-3 w-3" />}
                       label="Wind"
                       value={
-                        metar.wspd !== undefined
-                          ? `${metar.wdir ?? "VRB"}° ${metar.wspd}kt${metar.wgst ? ` G${metar.wgst}` : ""}`
-                          : "Calm"
+                        formatWindFromKnots(
+                          metar.wdir,
+                          metar.wspd,
+                          metar.wgst,
+                          settings.unitSystem,
+                        )
                       }
                     />
 
@@ -268,7 +273,7 @@ export function AirportInfoCard({ airport, onClose }: AirportInfoCardProps) {
                     <WeatherMetric
                       icon={<Eye className="h-3 w-3" />}
                       label="Visibility"
-                      value={formatVisibility(metar.visib)}
+                      value={formatVisibility(metar.visib, settings.unitSystem)}
                     />
 
                     {/* Temperature */}
@@ -277,7 +282,7 @@ export function AirportInfoCard({ airport, onClose }: AirportInfoCardProps) {
                       label="Temp / Dew"
                       value={
                         metar.temp !== undefined
-                          ? `${metar.temp}°C / ${metar.dewp ?? "—"}°C`
+                          ? `${formatTemperatureC(metar.temp, settings.unitSystem)} / ${formatTemperatureC(metar.dewp, settings.unitSystem)}`
                           : "—"
                       }
                     />
@@ -287,9 +292,7 @@ export function AirportInfoCard({ airport, onClose }: AirportInfoCardProps) {
                       icon={<Gauge className="h-3 w-3" />}
                       label="QNH"
                       value={
-                        metar.altim !== undefined
-                          ? `${metar.altim.toFixed(0)} hPa`
-                          : "—"
+                        formatPressureHpa(metar.altim, settings.unitSystem)
                       }
                     />
                   </div>
@@ -306,7 +309,7 @@ export function AirportInfoCard({ airport, onClose }: AirportInfoCardProps) {
                           {metar.clouds
                             .map(
                               (c) =>
-                                `${cloudCoverLabel(c.cover)}${c.base != null ? ` ${(c.base * 100).toLocaleString()}ft` : ""}`,
+                                `${cloudCoverLabel(c.cover)}${formatCloudBaseHundredsFeet(c.base, settings.unitSystem)}`,
                             )
                             .join(" · ")}
                         </p>

--- a/src/components/ui/altitude-legend.tsx
+++ b/src/components/ui/altitude-legend.tsx
@@ -1,8 +1,13 @@
 "use client";
 
 import { motion } from "motion/react";
+import { useSettings } from "@/hooks/use-settings";
+import { formatAltitude } from "@/lib/unit-formatters";
 
 export function AltitudeLegend() {
+  const { settings } = useSettings();
+  const ticks = [13000, 6096, 3048, 1524, 610, 152, 0];
+
   return (
     <motion.div
       initial={{ opacity: 0, x: 12 }}
@@ -14,7 +19,7 @@ export function AltitudeLegend() {
         backgroundColor: "rgb(var(--ui-bg) / 0.5)",
       }}
       role="img"
-      aria-label="Altitude color scale from 0 feet (green) to 43,000 feet (blue)"
+      aria-label={`Altitude color scale from ${formatAltitude(0, settings.unitSystem)} (green) to ${formatAltitude(13000, settings.unitSystem)} (blue)`}
     >
       <p
         className="text-[10px] font-semibold tracking-widest uppercase"
@@ -31,48 +36,15 @@ export function AltitudeLegend() {
           }}
         />
         <div className="flex h-32 flex-col justify-between">
-          <span
-            className="text-[10px] font-medium"
-            style={{ color: "rgb(var(--ui-fg) / 0.5)" }}
-          >
-            43,000 ft
-          </span>
-          <span
-            className="text-[10px] font-medium"
-            style={{ color: "rgb(var(--ui-fg) / 0.5)" }}
-          >
-            20,000 ft
-          </span>
-          <span
-            className="text-[10px] font-medium"
-            style={{ color: "rgb(var(--ui-fg) / 0.5)" }}
-          >
-            10,000 ft
-          </span>
-          <span
-            className="text-[10px] font-medium"
-            style={{ color: "rgb(var(--ui-fg) / 0.5)" }}
-          >
-            5,000 ft
-          </span>
-          <span
-            className="text-[10px] font-medium"
-            style={{ color: "rgb(var(--ui-fg) / 0.5)" }}
-          >
-            2,000 ft
-          </span>
-          <span
-            className="text-[10px] font-medium"
-            style={{ color: "rgb(var(--ui-fg) / 0.5)" }}
-          >
-            500 ft
-          </span>
-          <span
-            className="text-[10px] font-medium"
-            style={{ color: "rgb(var(--ui-fg) / 0.5)" }}
-          >
-            0 ft
-          </span>
+          {ticks.map((tick) => (
+            <span
+              key={tick}
+              className="text-[10px] font-medium"
+              style={{ color: "rgb(var(--ui-fg) / 0.5)" }}
+            >
+              {formatAltitude(tick, settings.unitSystem)}
+            </span>
+          ))}
         </div>
       </div>
     </motion.div>

--- a/src/components/ui/control-panel-search.tsx
+++ b/src/components/ui/control-panel-search.tsx
@@ -21,10 +21,10 @@ import type { FlightState } from "@/lib/opensky";
 import {
   formatCallsign,
   altitudeToColor,
-  metersToFeet,
-  msToKnots,
   headingToCardinal,
 } from "@/lib/flight-utils";
+import { useSettings } from "@/hooks/use-settings";
+import { formatAltitude, formatSpeed } from "@/lib/unit-formatters";
 
 // ── Recent searches (localStorage) ─────────────────────────────────────
 
@@ -248,6 +248,7 @@ export function SearchContent({
   activeFlightIcao24: string | null;
   onLookupFlight: (query: string, enterFpv?: boolean) => Promise<boolean>;
 }) {
+  const { settings } = useSettings();
   const [query, setQuery] = useState("");
   const [lookupBusy, setLookupBusy] = useState(false);
   const [lookupError, setLookupError] = useState<string | null>(null);
@@ -605,13 +606,13 @@ export function SearchContent({
                     {flight.baroAltitude != null && (
                       <span className="inline-flex items-center gap-1 rounded-md bg-foreground/3 px-1.5 py-0.5 text-[9px] font-medium text-foreground/30">
                         <AltitudeDot altitude={flight.baroAltitude} />
-                        {metersToFeet(flight.baroAltitude)}
+                        {formatAltitude(flight.baroAltitude, settings.unitSystem)}
                       </span>
                     )}
                     {flight.velocity != null && (
                       <span className="inline-flex items-center gap-1 rounded-md bg-foreground/3 px-1.5 py-0.5 text-[9px] font-medium text-foreground/30">
                         <Gauge className="h-2.5 w-2.5 text-foreground/20" />
-                        {msToKnots(flight.velocity)}
+                        {formatSpeed(flight.velocity, settings.unitSystem)}
                       </span>
                     )}
                     {flight.trueTrack != null && (

--- a/src/components/ui/control-panel-settings.tsx
+++ b/src/components/ui/control-panel-settings.tsx
@@ -9,6 +9,7 @@ import {
   Palette,
   Globe,
   ArrowLeftRight,
+  Ruler,
   Shield,
   Flame,
   Eye,
@@ -21,6 +22,7 @@ import {
   WEATHER_RADAR_OPACITY_MIN,
   WEATHER_RADAR_OPACITY_MAX,
   type OrbitDirection,
+  type UnitSystem,
   type Settings,
 } from "@/hooks/use-settings";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -52,6 +54,12 @@ const ALTITUDE_DISPLAY_MODES: {
 }[] = [
   { label: "Presentation", value: "presentation" },
   { label: "Realistic", value: "realistic" },
+];
+
+const UNIT_SYSTEMS: { label: string; value: UnitSystem }[] = [
+  { label: "Aviation", value: "aviation" },
+  { label: "Metric", value: "metric" },
+  { label: "Imperial", value: "imperial" },
 ];
 
 export function SettingsContent() {
@@ -129,6 +137,17 @@ export function SettingsContent() {
           options={ALTITUDE_DISPLAY_MODES}
           value={settings.altitudeDisplayMode}
           onChange={(v) => update("altitudeDisplayMode", v)}
+        />
+
+        {/* ── Units ── */}
+        <SectionHeader title="Units" />
+
+        <SegmentRow
+          icon={<Ruler className="h-4 w-4" />}
+          title="Unit system"
+          options={UNIT_SYSTEMS}
+          value={settings.unitSystem}
+          onChange={(v) => update("unitSystem", v)}
         />
 
         {/* ── Airspace ── */}

--- a/src/components/ui/flight-card.tsx
+++ b/src/components/ui/flight-card.tsx
@@ -26,9 +26,8 @@ import { HeroBanner } from "@/components/ui/hero-banner";
 import type { FlightState, FlightTrack } from "@/lib/opensky";
 import { VerticalProfile } from "@/components/ui/vertical-profile";
 import type { TrailEntry } from "@/hooks/use-trail-history";
+import { useSettings } from "@/hooks/use-settings";
 import {
-  metersToFeet,
-  msToKnots,
   formatCallsign,
   headingToCardinal,
 } from "@/lib/flight-utils";
@@ -43,6 +42,11 @@ import {
 } from "@/lib/logo-cache";
 import { useRouteInfo } from "@/hooks/use-route-info";
 import { formatAirportCode } from "@/lib/route-lookup";
+import {
+  formatAltitude,
+  formatSpeed,
+  formatVerticalSpeed,
+} from "@/lib/unit-formatters";
 
 type FlightCardProps = {
   flight: FlightState | null;
@@ -61,6 +65,7 @@ export function FlightCard({
   onToggleFpv,
   isFpvActive = false,
 }: FlightCardProps) {
+  const { settings } = useSettings();
   const routeInfo = useRouteInfo(flight, track);
   const airline = flight ? lookupAirline(flight.callsign) : null;
   const flightNum = flight ? parseFlightNumber(flight.callsign) : null;
@@ -267,12 +272,12 @@ export function FlightCard({
                 <Metric
                   icon={<ArrowUp className="h-3 w-3" />}
                   label="Altitude"
-                  value={metersToFeet(flight.baroAltitude)}
+                  value={formatAltitude(flight.baroAltitude, settings.unitSystem)}
                 />
                 <Metric
                   icon={<Gauge className="h-3 w-3" />}
                   label="Speed"
-                  value={msToKnots(flight.velocity)}
+                  value={formatSpeed(flight.velocity, settings.unitSystem)}
                 />
                 <Metric
                   icon={<Compass className="h-3 w-3" />}
@@ -286,12 +291,10 @@ export function FlightCard({
                 <Metric
                   icon={<ArrowDown className="h-3 w-3" />}
                   label="V/S"
-                  value={
-                    flight.verticalRate !== null &&
-                    Number.isFinite(flight.verticalRate)
-                      ? `${flight.verticalRate > 0 ? "+" : ""}${Math.round(flight.verticalRate)} m/s`
-                      : "—"
-                  }
+                  value={formatVerticalSpeed(
+                    flight.verticalRate,
+                    settings.unitSystem,
+                  )}
                 />
               </div>
 

--- a/src/components/ui/fpv-hud.tsx
+++ b/src/components/ui/fpv-hud.tsx
@@ -25,6 +25,18 @@ import {
   markAirlineLogoFailed,
   wasAirlineLogoRecentlyFailed,
 } from "@/lib/logo-cache";
+import { useSettings } from "@/hooks/use-settings";
+import {
+  altitudeValueFromFeet,
+  altitudeValueFromMeters,
+  altitudeUnitLabel,
+  formatTemperatureC,
+  formatVerticalSpeedValue,
+  speedValueFromKnots,
+  speedValueFromMs,
+  speedUnitLabel,
+  verticalSpeedUnitLabel,
+} from "@/lib/unit-formatters";
 
 type FpvHudProps = {
   flight: FlightState;
@@ -138,38 +150,37 @@ function CompassRibbon({ heading }: { heading: number | null }) {
 }
 
 export function FpvHud({ flight, onExit }: FpvHudProps) {
-  const altFeet =
-    flight.baroAltitude !== null && Number.isFinite(flight.baroAltitude)
-      ? Math.round(flight.baroAltitude * 3.28084)
-      : null;
-  const speedKts =
-    flight.velocity !== null && Number.isFinite(flight.velocity)
-      ? Math.round(flight.velocity * 1.944)
-      : null;
+  const { settings } = useSettings();
+  const altDisplay = altitudeValueFromMeters(
+    flight.baroAltitude,
+    settings.unitSystem,
+  );
+  const speedDisplay = speedValueFromMs(flight.velocity, settings.unitSystem);
   const heading =
     flight.trueTrack !== null && Number.isFinite(flight.trueTrack)
       ? flight.trueTrack
       : null;
   const cardinal = heading !== null ? headingToCardinal(heading) : null;
   const vs = flight.verticalRate;
-  const vsFpm =
-    vs !== null && Number.isFinite(vs) ? Math.round(vs * 196.85) : null;
-  const vsDisplay = vsFpm !== null ? `${vsFpm > 0 ? "+" : ""}${vsFpm}` : null;
+  const vsDisplay = formatVerticalSpeedValue(vs, settings.unitSystem);
 
   // ── Avionics data (readsb only) ────────────────────────────────────
-  const iasKts = flight.ias ?? null;
+  const iasDisplay = speedValueFromKnots(flight.ias, settings.unitSystem);
   const machNum = flight.mach ?? null;
   const windDir = flight.windDirection ?? null;
-  const windSpd = flight.windSpeed ?? null;
+  const windSpd = speedValueFromKnots(flight.windSpeed, settings.unitSystem);
   const oatC = flight.oat ?? null;
-  const selAlt = flight.navAltitudeMcp ?? null;
+  const selAlt = altitudeValueFromFeet(
+    flight.navAltitudeMcp,
+    settings.unitSystem,
+  );
   const navModes = flight.navModes ?? null;
   const rollDeg = flight.roll ?? null;
   const isMilitary = (flight.dbFlags ?? 0) & 1;
   const emergencyStatus = flight.emergencyStatus ?? null;
 
   const hasAvionicsRow =
-    iasKts !== null ||
+    iasDisplay !== null ||
     machNum !== null ||
     (windDir !== null && windSpd !== null) ||
     oatC !== null;
@@ -348,9 +359,9 @@ export function FpvHud({ flight, onExit }: FpvHudProps) {
               </span>
             </div>
             <p className="text-[13px] font-bold tabular-nums text-foreground/90">
-              {altFeet !== null ? altFeet.toLocaleString() : "—"}
-            </p>
-            <p className="text-[8px] font-medium text-foreground/25">ft</p>
+               {altDisplay !== null ? altDisplay.toLocaleString() : "—"}
+             </p>
+            <p className="text-[8px] font-medium text-foreground/25">{altitudeUnitLabel(settings.unitSystem)}</p>
           </div>
 
           <div className="flex min-w-11 flex-col items-center justify-center border-r border-foreground/6 px-2.5 py-1.5 sm:min-w-14 sm:px-2.5">
@@ -361,9 +372,9 @@ export function FpvHud({ flight, onExit }: FpvHudProps) {
               </span>
             </div>
             <p className="text-[13px] font-bold tabular-nums text-foreground/90">
-              {speedKts ?? "—"}
-            </p>
-            <p className="text-[8px] font-medium text-foreground/25">kts</p>
+               {speedDisplay ?? "—"}
+             </p>
+            <p className="text-[8px] font-medium text-foreground/25">{speedUnitLabel(settings.unitSystem)}</p>
           </div>
 
           <div className="flex min-w-12 flex-col items-center justify-center border-r border-foreground/6 px-2.5 py-1.5 sm:min-w-16 sm:px-2.5">
@@ -375,16 +386,16 @@ export function FpvHud({ flight, onExit }: FpvHudProps) {
             </div>
             <p
               className={`text-[13px] font-bold tabular-nums ${
-                vs !== null && vs > 0.5
-                  ? "text-emerald-400/80"
-                  : vs !== null && vs < -0.5
+                 vs !== null && vs > 0.5
+                   ? "text-emerald-400/80"
+                 : vs !== null && vs < -0.5
                     ? "text-amber-400/80"
                     : "text-foreground/90"
               }`}
             >
-              {vsDisplay ?? "—"}
-            </p>
-            <p className="text-[8px] font-medium text-foreground/25">fpm</p>
+               {vsDisplay.text ?? "—"}
+             </p>
+            <p className="text-[8px] font-medium text-foreground/25">{verticalSpeedUnitLabel(settings.unitSystem)}</p>
           </div>
 
           <button
@@ -400,15 +411,15 @@ export function FpvHud({ flight, onExit }: FpvHudProps) {
         {/* ── Avionics strip (IAS, Mach, Wind, OAT) ──────────────── */}
         {hasAvionicsRow && (
           <div className="flex w-full items-center justify-center gap-3 border-t border-foreground/6 px-3 py-1 sm:gap-4">
-            {iasKts !== null && (
+            {iasDisplay !== null && (
               <span className="flex items-center gap-1 text-[10px] tabular-nums text-foreground/50">
                 <span className="text-[8px] font-semibold uppercase tracking-wider text-foreground/30">
                   IAS
                 </span>
                 <span className="font-bold text-foreground/70">
-                  {Math.round(iasKts)}
+                  {iasDisplay}
                 </span>
-                <span className="text-[8px] text-foreground/25">kts</span>
+                <span className="text-[8px] text-foreground/25">{speedUnitLabel(settings.unitSystem)}</span>
               </span>
             )}
             {machNum !== null && (
@@ -431,14 +442,14 @@ export function FpvHud({ flight, onExit }: FpvHudProps) {
                 <span className="font-bold text-foreground/70">
                   {Math.round(windSpd)}
                 </span>
-                <span className="text-[8px] text-foreground/25">kts</span>
+                <span className="text-[8px] text-foreground/25">{speedUnitLabel(settings.unitSystem)}</span>
               </span>
             )}
             {oatC !== null && (
               <span className="flex items-center gap-0.5 text-[10px] tabular-nums text-foreground/50">
                 <Thermometer className="h-2.5 w-2.5 text-foreground/30" />
                 <span className="font-bold text-foreground/70">
-                  {Math.round(oatC)}°C
+                  {formatTemperatureC(oatC, settings.unitSystem)}
                 </span>
               </span>
             )}
@@ -485,7 +496,7 @@ export function FpvHud({ flight, onExit }: FpvHudProps) {
                 <span className="font-bold text-cyan-400/70">
                   {selAlt.toLocaleString()}
                 </span>
-                <span className="text-[8px] text-foreground/25">ft</span>
+                <span className="text-[8px] text-foreground/25">{altitudeUnitLabel(settings.unitSystem)}</span>
               </span>
             )}
           </div>

--- a/src/components/ui/mobile-flight-toast.tsx
+++ b/src/components/ui/mobile-flight-toast.tsx
@@ -18,10 +18,9 @@ import {
 } from "lucide-react";
 import { useAircraftPhotos } from "@/hooks/use-aircraft-photos";
 import { useRouteInfo } from "@/hooks/use-route-info";
+import { useSettings } from "@/hooks/use-settings";
 import type { FlightState, FlightTrack } from "@/lib/opensky";
 import {
-  metersToFeet,
-  msToKnots,
   formatCallsign,
   headingToCardinal,
 } from "@/lib/flight-utils";
@@ -36,6 +35,11 @@ import {
   wasAirlineLogoRecentlyFailed,
 } from "@/lib/logo-cache";
 import type { NormalizedPhoto } from "@/hooks/use-aircraft-photos";
+import {
+  formatAltitude,
+  formatSpeed,
+  formatVerticalSpeedValue,
+} from "@/lib/unit-formatters";
 
 type MobileFlightToastProps = {
   flight: FlightState;
@@ -221,6 +225,7 @@ export function MobileFlightToast({
   onToggleFpv,
   isFpvActive = false,
 }: MobileFlightToastProps) {
+  const { settings } = useSettings();
   const airline = lookupAirline(flight.callsign);
   const flightNum = parseFlightNumber(flight.callsign);
   const company = airline ?? `${flight.originCountry} operator`;
@@ -454,12 +459,12 @@ export function MobileFlightToast({
         <MiniMetric
           icon={<ArrowUp className="h-2.5 w-2.5" />}
           label="ALT"
-          value={metersToFeet(flight.baroAltitude)}
+          value={formatAltitude(flight.baroAltitude, settings.unitSystem)}
         />
         <MiniMetric
           icon={<Gauge className="h-2.5 w-2.5" />}
           label="SPD"
-          value={msToKnots(flight.velocity)}
+          value={formatSpeed(flight.velocity, settings.unitSystem)}
         />
         <MiniMetric
           icon={<Compass className="h-2.5 w-2.5" />}
@@ -473,11 +478,10 @@ export function MobileFlightToast({
         <MiniMetric
           icon={<ArrowDown className="h-2.5 w-2.5" />}
           label="V/S"
-          value={
-            flight.verticalRate !== null && Number.isFinite(flight.verticalRate)
-              ? `${flight.verticalRate > 0 ? "+" : ""}${Math.round(flight.verticalRate)}`
-              : "—"
-          }
+          value={formatVerticalSpeedValue(
+            flight.verticalRate,
+            settings.unitSystem,
+          ).text}
         />
       </div>
 

--- a/src/components/ui/vertical-profile.tsx
+++ b/src/components/ui/vertical-profile.tsx
@@ -2,6 +2,8 @@
 
 import { useMemo } from "react";
 import type { TrailEntry } from "@/hooks/use-trail-history";
+import { useSettings } from "@/hooks/use-settings";
+import { formatAltitude, formatDistanceAxisNm } from "@/lib/unit-formatters";
 
 const PROFILE_HEIGHT = 100;
 const PROFILE_PADDING_TOP = 14;
@@ -77,6 +79,7 @@ export function VerticalProfile({
   trail,
   navAltitudeMcp,
 }: VerticalProfileProps) {
+  const { settings } = useSettings();
   const points = useMemo<ProfilePoint[]>(() => {
     if (!trail || trail.path.length < MIN_POINTS_TO_RENDER) return [];
 
@@ -166,10 +169,14 @@ export function VerticalProfile({
             Vertical Profile
           </p>
           <p className="font-mono text-[10px] tabular-nums text-foreground/25">
-            FL
-            {Math.round(points[points.length - 1].altFt / 100)
-              .toString()
-              .padStart(3, "0")}
+            {settings.unitSystem === "aviation"
+              ? `FL${Math.round(points[points.length - 1].altFt / 100)
+                  .toString()
+                  .padStart(3, "0")}`
+              : formatAltitude(
+                  points[points.length - 1].altMeters,
+                  settings.unitSystem,
+                )}
           </p>
         </div>
         <svg
@@ -221,11 +228,14 @@ export function VerticalProfile({
                 fontSize={6}
                 fontFamily="monospace"
               >
-                {a >= 1000
+                {settings.unitSystem === "aviation" && a >= 1000
                   ? `FL${Math.round(a / 100)
                       .toString()
                       .padStart(3, "0")}`
-                  : a}
+                  : formatAltitude(a / FEET_PER_METER, settings.unitSystem).replace(
+                      /\s/g,
+                      "",
+                    )}
               </text>
             </g>
           ))}
@@ -276,10 +286,14 @@ export function VerticalProfile({
                   fontFamily="monospace"
                   textAnchor="end"
                 >
-                  SEL FL
-                  {Math.round(navAltitudeMcp / 100)
-                    .toString()
-                    .padStart(3, "0")}
+                  {settings.unitSystem === "aviation"
+                    ? `SEL FL${Math.round(navAltitudeMcp / 100)
+                        .toString()
+                        .padStart(3, "0")}`
+                    : `SEL ${formatAltitude(
+                        navAltitudeMcp / FEET_PER_METER,
+                        settings.unitSystem,
+                      )}`}
                 </text>
               </>
             )}
@@ -320,7 +334,7 @@ export function VerticalProfile({
             fontSize={6}
             fontFamily="monospace"
           >
-            0 nm
+            {formatDistanceAxisNm(0, settings.unitSystem)}
           </text>
           <text
             x={200 - PROFILE_PADDING_X}
@@ -331,7 +345,7 @@ export function VerticalProfile({
             fontFamily="monospace"
             textAnchor="end"
           >
-            {maxDist.toFixed(0)} nm
+            {formatDistanceAxisNm(maxDist, settings.unitSystem)}
           </text>
         </svg>
       </div>

--- a/src/hooks/use-airport-board.ts
+++ b/src/hooks/use-airport-board.ts
@@ -1,10 +1,16 @@
 "use client";
 
 import { useMemo } from "react";
+import { useSettings } from "@/hooks/use-settings";
 import type { FlightState } from "@/lib/opensky";
 import type { Airport } from "@/lib/airports";
 import { findByIata } from "@/lib/airports";
-import { formatCallsign, metersToFeet, msToKnots } from "@/lib/flight-utils";
+import { formatCallsign } from "@/lib/flight-utils";
+import {
+  formatAltitude,
+  formatDistanceNm,
+  formatSpeed,
+} from "@/lib/unit-formatters";
 
 // ── Constants ──────────────────────────────────────────────────────────
 
@@ -282,12 +288,6 @@ function classifyFlight(
   };
 }
 
-function formatDistance(nm: number): string {
-  if (nm < 0.1) return "<0.1 nm";
-  if (nm < 10) return `${nm.toFixed(1)} nm`;
-  return `${Math.round(nm)} nm`;
-}
-
 // ── Hook ───────────────────────────────────────────────────────────────
 
 export function useAirportBoard(
@@ -298,6 +298,8 @@ export function useAirportBoard(
   /** When set, the board opens for this specific airport (user clicked the dot). */
   selectedAirportIata: string | null = null,
 ): AirportBoardData {
+  const { settings } = useSettings();
+
   return useMemo(() => {
     const inactive: AirportBoardData = {
       arrivals: [],
@@ -336,17 +338,20 @@ export function useAirportBoard(
       // Skip flights too far away
       if (dist > BOARD_RADIUS_NM) continue;
 
-      const boardFlight: BoardFlight = {
-        icao24: f.icao24,
-        callsign: formatCallsign(f.callsign),
-        direction,
-        altitude: metersToFeet(f.baroAltitude ?? f.geoAltitude),
-        altitudeMeters: f.baroAltitude ?? f.geoAltitude,
-        speed: msToKnots(f.velocity),
-        speedMs: f.velocity,
-        distanceNm: dist,
-        distanceFormatted: formatDistance(dist),
-        verticalRate: f.verticalRate,
+        const boardFlight: BoardFlight = {
+          icao24: f.icao24,
+          callsign: formatCallsign(f.callsign),
+          direction,
+          altitude: formatAltitude(
+            f.baroAltitude ?? f.geoAltitude,
+            settings.unitSystem,
+          ),
+          altitudeMeters: f.baroAltitude ?? f.geoAltitude,
+          speed: formatSpeed(f.velocity, settings.unitSystem),
+          speedMs: f.velocity,
+          distanceNm: dist,
+          distanceFormatted: formatDistanceNm(dist, settings.unitSystem),
+          verticalRate: f.verticalRate,
         heading: f.trueTrack,
         bearing: brng,
         bearingDiff: bDiff,
@@ -386,5 +391,5 @@ export function useAirportBoard(
       isActive: true,
       totalFlights: arrivals.length + departures.length,
     };
-  }, [flights, selectedAirportIata]);
+  }, [flights, selectedAirportIata, settings.unitSystem]);
 }

--- a/src/hooks/use-settings.tsx
+++ b/src/hooks/use-settings.tsx
@@ -15,6 +15,7 @@ import type { AltitudeDisplayMode } from "@/lib/altitude-display-mode";
 import { clamp } from "@/lib/utils";
 
 export type OrbitDirection = "clockwise" | "counter-clockwise";
+export type UnitSystem = "aviation" | "metric" | "imperial";
 
 export type Settings = {
   autoOrbit: boolean;
@@ -26,6 +27,7 @@ export type Settings = {
   showShadows: boolean;
   showAltitudeColors: boolean;
   altitudeDisplayMode: AltitudeDisplayMode;
+  unitSystem: UnitSystem;
   fpvChaseDistance: number;
   globeMode: boolean;
   showAirspace: boolean;
@@ -87,6 +89,7 @@ const DEFAULT_SETTINGS: Settings = {
   showShadows: true,
   showAltitudeColors: true,
   altitudeDisplayMode: "presentation",
+  unitSystem: "aviation",
   fpvChaseDistance: 0.0048,
   globeMode: false,
   showAirspace: false,
@@ -98,7 +101,7 @@ const DEFAULT_SETTINGS: Settings = {
 };
 
 const STORAGE_KEY = "aeris:settings";
-const STORAGE_VERSION = 2;
+const STORAGE_VERSION = 3;
 const WRITE_DEBOUNCE_MS = 300;
 
 type StorageEnvelope = {
@@ -127,6 +130,9 @@ function isValidSettings(obj: unknown): obj is Settings {
     typeof s.showAltitudeColors === "boolean" &&
     (s.altitudeDisplayMode === "presentation" ||
       s.altitudeDisplayMode === "realistic") &&
+    (s.unitSystem === "aviation" ||
+      s.unitSystem === "metric" ||
+      s.unitSystem === "imperial") &&
     typeof s.fpvChaseDistance === "number" &&
     Number.isFinite(s.fpvChaseDistance) &&
     s.fpvChaseDistance >= FPV_CHASE_DISTANCE_MIN &&

--- a/src/lib/flight-utils.ts
+++ b/src/lib/flight-utils.ts
@@ -1,5 +1,7 @@
 import type { AltitudeDisplayMode } from "@/lib/altitude-display-mode";
 import { projectDisplayedAltitudeMeters } from "@/components/map/altitude-projection";
+import type { UnitSystem } from "@/hooks/use-settings";
+import { formatAltitude, formatSpeed } from "@/lib/unit-formatters";
 
 const MAX_ALTITUDE_METERS = 13000;
 
@@ -57,13 +59,25 @@ export function altitudeToElevation(
 }
 
 export function metersToFeet(meters: number | null): string {
-  if (meters === null || !Number.isFinite(meters)) return "—";
-  return `${Math.round(meters * 3.28084).toLocaleString()} ft`;
+  return formatAltitude(meters, "aviation");
 }
 
 export function msToKnots(ms: number | null): string {
-  if (ms === null || !Number.isFinite(ms)) return "—";
-  return `${Math.round(ms * 1.94384)} kts`;
+  return formatSpeed(ms, "aviation");
+}
+
+export function formatAltitudeForUnits(
+  meters: number | null,
+  unitSystem: UnitSystem,
+): string {
+  return formatAltitude(meters, unitSystem);
+}
+
+export function formatSpeedForUnits(
+  ms: number | null,
+  unitSystem: UnitSystem,
+): string {
+  return formatSpeed(ms, unitSystem);
 }
 
 export function formatCallsign(callsign: string | null): string {

--- a/src/lib/unit-formatters.ts
+++ b/src/lib/unit-formatters.ts
@@ -1,0 +1,228 @@
+import type { UnitSystem } from "@/hooks/use-settings";
+
+const FT_PER_METER = 3.28084;
+const KTS_PER_MS = 1.94384;
+const FPM_PER_MS = 196.850394;
+const KM_PER_NM = 1.852;
+const MI_PER_NM = 1.15078;
+const MPH_PER_MS = 2.23694;
+const KMH_PER_MS = 3.6;
+const INHG_PER_HPA = 0.0295299830714;
+
+export function altitudeValueFromMeters(
+  meters: number | null,
+  unitSystem: UnitSystem,
+): number | null {
+  if (meters === null || !Number.isFinite(meters)) return null;
+  if (unitSystem === "metric") return Math.round(meters);
+  return Math.round(meters * FT_PER_METER);
+}
+
+export function altitudeValueFromFeet(
+  feet: number | null | undefined,
+  unitSystem: UnitSystem,
+): number | null {
+  if (feet == null || !Number.isFinite(feet)) return null;
+  if (unitSystem === "metric") return Math.round(feet / FT_PER_METER);
+  return Math.round(feet);
+}
+
+export function speedValueFromMs(
+  ms: number | null,
+  unitSystem: UnitSystem,
+): number | null {
+  if (ms === null || !Number.isFinite(ms)) return null;
+  if (unitSystem === "metric") return Math.round(ms * KMH_PER_MS);
+  if (unitSystem === "imperial") return Math.round(ms * MPH_PER_MS);
+  return Math.round(ms * KTS_PER_MS);
+}
+
+export function speedValueFromKnots(
+  knots: number | null | undefined,
+  unitSystem: UnitSystem,
+): number | null {
+  if (knots == null || !Number.isFinite(knots)) return null;
+  if (unitSystem === "metric") return Math.round(knots * KM_PER_NM);
+  if (unitSystem === "imperial") return Math.round(knots * MI_PER_NM);
+  return Math.round(knots);
+}
+
+export function formatAltitude(
+  meters: number | null,
+  unitSystem: UnitSystem,
+): string {
+  if (meters === null || !Number.isFinite(meters)) return "—";
+  if (unitSystem === "metric") {
+    return `${Math.round(meters).toLocaleString()} m`;
+  }
+  return `${Math.round(meters * FT_PER_METER).toLocaleString()} ft`;
+}
+
+export function formatSpeed(
+  ms: number | null,
+  unitSystem: UnitSystem,
+): string {
+  if (ms === null || !Number.isFinite(ms)) return "—";
+  if (unitSystem === "metric") {
+    return `${Math.round(ms * KMH_PER_MS).toLocaleString()} km/h`;
+  }
+  if (unitSystem === "imperial") {
+    return `${Math.round(ms * MPH_PER_MS).toLocaleString()} mph`;
+  }
+  return `${Math.round(ms * KTS_PER_MS).toLocaleString()} kts`;
+}
+
+export function formatVerticalSpeed(
+  ms: number | null,
+  unitSystem: UnitSystem,
+): string {
+  if (ms === null || !Number.isFinite(ms)) return "—";
+  if (unitSystem === "metric") {
+    return `${ms > 0 ? "+" : ""}${ms.toFixed(1)} m/s`;
+  }
+  const fpm = Math.round(ms * FPM_PER_MS);
+  return `${fpm > 0 ? "+" : ""}${fpm.toLocaleString()} fpm`;
+}
+
+export function formatVerticalSpeedValue(
+  ms: number | null,
+  unitSystem: UnitSystem,
+): { value: number | null; unitLabel: string; text: string } {
+  if (ms === null || !Number.isFinite(ms)) {
+    return {
+      value: null,
+      unitLabel: unitSystem === "metric" ? "m/s" : "fpm",
+      text: "—",
+    };
+  }
+
+  if (unitSystem === "metric") {
+    const rounded = Math.round(ms * 10) / 10;
+    return {
+      value: rounded,
+      unitLabel: "m/s",
+      text: `${rounded > 0 ? "+" : ""}${rounded.toFixed(1)}`,
+    };
+  }
+
+  const fpm = Math.round(ms * FPM_PER_MS);
+  return {
+    value: fpm,
+    unitLabel: "fpm",
+    text: `${fpm > 0 ? "+" : ""}${fpm.toLocaleString()}`,
+  };
+}
+
+export function formatDistanceNm(
+  nm: number,
+  unitSystem: UnitSystem,
+): string {
+  if (!Number.isFinite(nm)) return "—";
+  if (unitSystem === "metric") {
+    const km = nm * KM_PER_NM;
+    if (km < 0.1) return "<0.1 km";
+    if (km < 10) return `${km.toFixed(1)} km`;
+    return `${Math.round(km).toLocaleString()} km`;
+  }
+  if (unitSystem === "imperial") {
+    const mi = nm * MI_PER_NM;
+    if (mi < 0.1) return "<0.1 mi";
+    if (mi < 10) return `${mi.toFixed(1)} mi`;
+    return `${Math.round(mi).toLocaleString()} mi`;
+  }
+  if (nm < 0.1) return "<0.1 nm";
+  if (nm < 10) return `${nm.toFixed(1)} nm`;
+  return `${Math.round(nm).toLocaleString()} nm`;
+}
+
+export function formatDistanceAxisNm(
+  nm: number,
+  unitSystem: UnitSystem,
+): string {
+  if (!Number.isFinite(nm)) return "—";
+  if (unitSystem === "metric") return `${Math.round(nm * KM_PER_NM)} km`;
+  if (unitSystem === "imperial") return `${Math.round(nm * MI_PER_NM)} mi`;
+  return `${Math.round(nm)} nm`;
+}
+
+export function formatTemperatureC(
+  celsius: number | null | undefined,
+  unitSystem: UnitSystem,
+): string {
+  if (celsius == null || !Number.isFinite(celsius)) return "—";
+  if (unitSystem === "imperial") {
+    return `${Math.round((celsius * 9) / 5 + 32)}°F`;
+  }
+  return `${Math.round(celsius)}°C`;
+}
+
+export function formatPressureHpa(
+  hpa: number | null | undefined,
+  unitSystem: UnitSystem,
+): string {
+  if (hpa == null || !Number.isFinite(hpa)) return "—";
+  if (unitSystem === "imperial") {
+    return `${(hpa * INHG_PER_HPA).toFixed(2)} inHg`;
+  }
+  return `${hpa.toFixed(0)} hPa`;
+}
+
+export function formatVisibility(
+  vis: number | string | undefined,
+  unitSystem: UnitSystem,
+): string {
+  if (vis === undefined || vis === null) return "—";
+  if (typeof vis === "string") return vis;
+  if (unitSystem === "metric") {
+    if (vis >= 9999) return "16+ km";
+    return `${Math.round(vis * 1.60934)} km`;
+  }
+  if (vis >= 9999) return "10+ SM";
+  return `${vis} SM`;
+}
+
+export function formatWindFromKnots(
+  direction: number | string | undefined,
+  speedKt: number | undefined,
+  gustKt: number | undefined,
+  unitSystem: UnitSystem,
+): string {
+  if (speedKt === undefined) return "Calm";
+
+  const speed = speedValueFromKnots(speedKt, unitSystem);
+  const gust = speedValueFromKnots(gustKt, unitSystem);
+  const unitLabel =
+    unitSystem === "metric"
+      ? "km/h"
+      : unitSystem === "imperial"
+        ? "mph"
+        : "kt";
+
+  return `${direction ?? "VRB"}° ${speed}${unitLabel}${gust === null ? "" : ` G${gust}`}`;
+}
+
+export function formatCloudBaseHundredsFeet(
+  baseHundredsFeet: number | null | undefined,
+  unitSystem: UnitSystem,
+): string {
+  if (baseHundredsFeet == null || !Number.isFinite(baseHundredsFeet)) return "";
+  const feet = baseHundredsFeet * 100;
+  if (unitSystem === "metric") {
+    return ` ${Math.round(feet / FT_PER_METER).toLocaleString()}m`;
+  }
+  return ` ${feet.toLocaleString()}ft`;
+}
+
+export function altitudeUnitLabel(unitSystem: UnitSystem): string {
+  return unitSystem === "metric" ? "m" : "ft";
+}
+
+export function speedUnitLabel(unitSystem: UnitSystem): string {
+  if (unitSystem === "metric") return "km/h";
+  if (unitSystem === "imperial") return "mph";
+  return "kts";
+}
+
+export function verticalSpeedUnitLabel(unitSystem: UnitSystem): string {
+  return unitSystem === "metric" ? "m/s" : "fpm";
+}


### PR DESCRIPTION
## Summary
- add a new `Unit system` setting with `Aviation`, `Metric`, and `Imperial` options, persisted through the existing settings store
- centralize unit conversions and formatting in shared helpers, then update the main flight and weather UI surfaces to respect the selected unit system
- follow up by moving more airport weather formatting into the shared formatter layer so the airport info card no longer maintains separate local unit helpers
- keep all internal flight logic and thresholds unchanged so this only affects user-facing display values and labels

## Best Review Approach
1. Open Settings and switch between `Aviation`, `Metric`, and `Imperial`.
2. Reload once to confirm the preference persists.
3. Spot-check these surfaces for both value conversion and unit labels:
   - Flight card
   - Mobile flight toast
   - Search result chips
   - Airport board
   - FPV HUD
   - Altitude legend
   - Airport weather card
   - Vertical profile
4. Verify expected mappings:
   - `Aviation`: `ft`, `kts`, `fpm`, `nm`, `°C`, `hPa`
   - `Metric`: `m`, `km/h`, `m/s`, `km`, `°C`, `hPa`
   - `Imperial`: `ft`, `mph`, `fpm`, `mi`, `°F`, `inHg`
5. In code review, skim `src/lib/unit-formatters.ts` first, then confirm UI consumers are using shared helpers rather than inline conversions.

(created using OpenCode and GPT-5.4)

Closes #19
