### PR TITLE
feat: add airplanes.live 2.0 support and adsb.fi fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,5 +29,5 @@
 # OPENAIP_API_KEY=
 
 # --- Notes ------------------------------------------------------------------
-# Public ADS-B providers (airplanes.live, adsb.lol) are called directly
-# from the browser with CORS, so they do not need credentials.
+# Public readsb providers (adsb.lol, then airplanes.live) are accessed through
+# the server proxy. Aeris does not configure provider credentials.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ All variables are optional - Aeris runs with no secrets. See `.env.example` for 
 | `OPENSKY_CLIENT_SECRET` | No       | OAuth2 secret that pairs with `OPENSKY_CLIENT_ID`. Set both or neither.                                                                                                                                               |
 | `OPENAIP_API_KEY`       | No       | API key used by the airspace vector-tile proxy `src/app/api/airspace-tiles/route.ts`. Without it the airspace overlay is disabled cleanly and the client skips OpenAIP tile requests; flight rendering is unaffected. |
 
-Live readsb data (adsb.lol, adsb.fi, then airplanes.live) is fetched through the server proxy; OpenSky is the final automatic fallback. No provider credentials are configured. adsb.fi is limited to personal, non-commercial use and is credited in the application as required by its terms.
+Live readsb data (adsb.lol, adsb.fi, then airplanes.live) is fetched through the server proxy; OpenSky is the final automatic fallback. No provider credentials are configured. The adsb.fi public API is limited to one request per second per IP for personal, non-commercial use and is credited in the application as required by its terms.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Aeris renders live air traffic over the world's busiest airspaces on a premium d
 | Map       | MapLibre GL JS                                                   |
 | WebGL     | Deck.gl 9 (ScenegraphLayer, IconLayer, PathLayer, MapboxOverlay) |
 | Animation | Motion (Framer Motion)                                           |
-| Data      | Airplanes.live / adsb.lol / OpenSky (3-tier fallback)            |
+| Data      | adsb.lol / airplanes.live / OpenSky (3-tier fallback)            |
 | Hosting   | Vercel                                                           |
 
 ## Getting Started
@@ -43,7 +43,7 @@ src/
 │   ├── globals.css            Tailwind config, theme vars
 │   ├── layout.tsx             Root layout (Inter font)
 │   ├── page.tsx               Entry - renders <FlightTracker />
-│   └── api/flights/route.ts   adsb.lol reverse proxy (CORS workaround + rate limit)
+│   └── api/flights/route.ts   readsb provider proxy (validation + rate limiting)
 ├── components/
 │   ├── flight-tracker.tsx     Orchestrator - state, camera, layers, UI
 │   ├── map/
@@ -65,7 +65,7 @@ src/
 └── lib/
     ├── cities.ts              Curated aviation hub presets
     ├── flight-api.ts          Barrel re-export for the 3-tier flight client
-    ├── flight-api-client.ts   airplanes.live → adsb.lol → OpenSky fallback chain
+    ├── flight-api-client.ts   adsb.lol → airplanes.live → OpenSky fallback chain
     ├── flight-api-parsing.ts  readsb JSON → FlightState normalization
     ├── flight-api-types.ts    Shared types for ADS-B providers
     ├── flight-utils.ts        Altitude→color, unit conversions
@@ -120,7 +120,7 @@ All variables are optional - Aeris runs with no secrets. See `.env.example` for 
 | `OPENSKY_CLIENT_SECRET` | No       | OAuth2 secret that pairs with `OPENSKY_CLIENT_ID`. Set both or neither.                                                                                                                                               |
 | `OPENAIP_API_KEY`       | No       | API key used by the airspace vector-tile proxy `src/app/api/airspace-tiles/route.ts`. Without it the airspace overlay is disabled cleanly and the client skips OpenAIP tile requests; flight rendering is unaffected. |
 
-Live flight data (airplanes.live, adsb.lol) is called directly from the browser with CORS - no credentials needed.
+Live readsb data (adsb.lol, then airplanes.live) is fetched through the server proxy; OpenSky is the final automatic fallback. No provider credentials are configured.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Aeris renders live air traffic over the world's busiest airspaces on a premium d
 | Map       | MapLibre GL JS                                                   |
 | WebGL     | Deck.gl 9 (ScenegraphLayer, IconLayer, PathLayer, MapboxOverlay) |
 | Animation | Motion (Framer Motion)                                           |
-| Data      | adsb.lol / airplanes.live / OpenSky (3-tier fallback)            |
+| Data      | adsb.lol / adsb.fi / airplanes.live / OpenSky (4-tier fallback)  |
 | Hosting   | Vercel                                                           |
 
 ## Getting Started
@@ -64,13 +64,13 @@ src/
 │   └── use-trail-history.ts   Trail accumulation + Catmull-Rom smoothing
 └── lib/
     ├── cities.ts              Curated aviation hub presets
-    ├── flight-api.ts          Barrel re-export for the 3-tier flight client
-    ├── flight-api-client.ts   adsb.lol → airplanes.live → OpenSky fallback chain
+    ├── flight-api.ts          Barrel re-export for the 4-tier flight client
+    ├── flight-api-client.ts   adsb.lol → adsb.fi → airplanes.live → OpenSky fallback chain
     ├── flight-api-parsing.ts  readsb JSON → FlightState normalization
     ├── flight-api-types.ts    Shared types for ADS-B providers
     ├── flight-utils.ts        Altitude→color, unit conversions
     ├── map-styles.ts          Map style definitions
-    ├── opensky.ts             OpenSky API client + types (Tier 3 fallback)
+    ├── opensky.ts             OpenSky API client + types (Tier 4 fallback)
     └── utils.ts               cn() utility
 ```
 
@@ -120,7 +120,7 @@ All variables are optional - Aeris runs with no secrets. See `.env.example` for 
 | `OPENSKY_CLIENT_SECRET` | No       | OAuth2 secret that pairs with `OPENSKY_CLIENT_ID`. Set both or neither.                                                                                                                                               |
 | `OPENAIP_API_KEY`       | No       | API key used by the airspace vector-tile proxy `src/app/api/airspace-tiles/route.ts`. Without it the airspace overlay is disabled cleanly and the client skips OpenAIP tile requests; flight rendering is unaffected. |
 
-Live readsb data (adsb.lol, then airplanes.live) is fetched through the server proxy; OpenSky is the final automatic fallback. No provider credentials are configured.
+Live readsb data (adsb.lol, adsb.fi, then airplanes.live) is fetched through the server proxy; OpenSky is the final automatic fallback. No provider credentials are configured. adsb.fi is limited to personal, non-commercial use and is credited in the application as required by its terms.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aeris",
-  "version": "0.8.6",
+  "version": "0.8.8",
   "description": "Real-time 3D flight tracking - altitude-aware, visually stunning.",
   "author": "kewonit",
   "license": "AGPL-3.0",

--- a/src/app/api/aircraft-photos/route.ts
+++ b/src/app/api/aircraft-photos/route.ts
@@ -6,7 +6,7 @@ const JETAPI_TIMEOUT_MS = 5_000;
 const HEX_REGEX = /^[0-9a-f]{6}$/;
 const REG_REGEX = /^[A-Z0-9][A-Z0-9-]{1,9}$/;
 const UPSTREAM_USER_AGENT =
-  "AerisFlightTracker/0.8 (+https://github.com/kewonit/aeris)";
+  "AerisFlightTracker/0.8.8 (+https://github.com/kewonit/aeris)";
 
 // ── Upstream types ──────────────────────────────────────────────────────────
 

--- a/src/app/api/flights/route.test.ts
+++ b/src/app/api/flights/route.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { NextRequest } from "next/server";
+
+import { GET } from "./route";
+
+function request(path: string, provider?: string): NextRequest {
+  const url = new URL("http://localhost/api/flights");
+  url.searchParams.set("path", path);
+  if (provider) url.searchParams.set("provider", provider);
+  return new NextRequest(url);
+}
+
+function readsbEnvelope() {
+  return { ac: [], msg: "No error", now: 1, total: 0 };
+}
+
+test("constructs provider URLs and sends identifying headers", async () => {
+  const calls: Array<{ url: string; headers: Headers }> = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({
+      url: input.toString(),
+      headers: new Headers(init?.headers),
+    });
+    return Response.json(readsbEnvelope());
+  };
+
+  try {
+    assert.equal(
+      (await GET(request("/point/12.5/77.6/25.5", "adsb"))).status,
+      200,
+    );
+    assert.equal(
+      (await GET(request("/hex/abc123", "airplanes"))).status,
+      200,
+    );
+
+    assert.equal(
+      calls[0].url,
+      "https://api.adsb.lol/v2/point/12.5/77.6/25.5",
+    );
+    assert.equal(
+      calls[1].url,
+      "https://api.airplanes.live/v2/hex/abc123",
+    );
+    for (const call of calls) {
+      assert.equal(call.headers.get("accept"), "application/json");
+      assert.match(
+        call.headers.get("user-agent") ?? "",
+        /^AerisFlightTracker\//,
+      );
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("rejects invalid providers, geographic bounds, and SSRF paths", async () => {
+  let fetchCount = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    fetchCount++;
+    return Response.json(readsbEnvelope());
+  };
+
+  try {
+    const cases: Array<[string, string?]> = [
+      ["/point/90.1/0/1"],
+      ["/point/0/180.1/1"],
+      ["/point/0/0/250.1"],
+      ["/point/0/0/-1"],
+      ["https://example.com/v2/hex/abc123"],
+      ["/hex/abc123/../../status"],
+      ["/hex/abc123", "__proto__"],
+    ];
+
+    for (const [path, provider] of cases) {
+      assert.equal((await GET(request(path, provider))).status, 400);
+    }
+    assert.equal(fetchCount, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("rejects malformed and non-JSON upstream responses", async (t) => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    await t.test("malformed JSON", async () => {
+      globalThis.fetch = async () =>
+        new Response("{", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      assert.equal((await GET(request("/hex/abc123", "adsb"))).status, 502);
+    });
+
+    await t.test("HTML challenge", async () => {
+      globalThis.fetch = async () =>
+        new Response("<html></html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        });
+      assert.equal(
+        (await GET(request("/hex/abc123", "airplanes"))).status,
+        502,
+      );
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("maps timeouts and upstream HTTP failures correctly", async (t) => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    await t.test("timeout", async () => {
+      globalThis.fetch = async () => {
+        throw new DOMException("Aborted", "AbortError");
+      };
+      assert.equal((await GET(request("/hex/abc123", "adsb"))).status, 504);
+    });
+
+    for (const [upstream, expected] of [
+      [401, 401],
+      [403, 403],
+      [429, 429],
+      [500, 502],
+      [503, 502],
+    ] as const) {
+      await t.test(`${upstream} -> ${expected}`, async () => {
+        globalThis.fetch = async () => new Response(null, { status: upstream });
+        assert.equal(
+          (await GET(request("/callsign/BAW123", "adsb"))).status,
+          expected,
+        );
+      });
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/src/app/api/flights/route.test.ts
+++ b/src/app/api/flights/route.test.ts
@@ -32,6 +32,14 @@ test("constructs provider URLs and sends identifying headers", async () => {
       200,
     );
     assert.equal(
+      (await GET(request("/point/60.3179/24.9496/25", "adsbfi"))).status,
+      200,
+    );
+    assert.equal(
+      (await GET(request("/hex/461e1a", "adsbfi"))).status,
+      200,
+    );
+    assert.equal(
       (await GET(request("/hex/abc123", "airplanes"))).status,
       200,
     );
@@ -42,6 +50,14 @@ test("constructs provider URLs and sends identifying headers", async () => {
     );
     assert.equal(
       calls[1].url,
+      "https://opendata.adsb.fi/api/v3/lat/60.3179/lon/24.9496/dist/25",
+    );
+    assert.equal(
+      calls[2].url,
+      "https://opendata.adsb.fi/api/v2/hex/461e1a",
+    );
+    assert.equal(
+      calls[3].url,
       "https://api.airplanes.live/v2/hex/abc123",
     );
     for (const call of calls) {

--- a/src/app/api/flights/route.ts
+++ b/src/app/api/flights/route.ts
@@ -3,11 +3,13 @@ import { READSB_FETCH_TIMEOUT_MS, MAX_RADIUS_NM } from "@/lib/flight-api-types";
 
 // ── Multi-Provider Proxy ───────────────────────────────────────────────
 //
-// Proxies readsb-format requests to adsb.lol or airplanes.live.
-// Both lack browser-compatible CORS headers, so server-side proxy is required.
+// Proxies readsb-format requests to adsb.lol, adsb.fi, or airplanes.live.
+// These APIs lack browser-compatible CORS headers, so a server-side proxy is
+// required.
 //
 // Usage:
 //   /api/flights?path=/point/lat/lon/radius              → adsb.lol (default)
+//   /api/flights?path=/point/lat/lon/radius&provider=adsbfi → adsb.fi
 //   /api/flights?path=/hex/abcdef&provider=airplanes      → airplanes.live
 //   /api/flights?path=/callsign/BAW123&provider=adsb      → adsb.lol
 //
@@ -17,7 +19,7 @@ import { READSB_FETCH_TIMEOUT_MS, MAX_RADIUS_NM } from "@/lib/flight-api-types";
 
 // ── Provider Configuration ─────────────────────────────────────────────
 
-type ProviderKey = "adsb" | "airplanes";
+type ProviderKey = "adsb" | "adsbfi" | "airplanes";
 
 interface ProviderConfig {
   baseUrl: string;
@@ -31,6 +33,11 @@ const PROVIDERS: Record<ProviderKey, ProviderConfig> = {
     baseUrl: "https://api.adsb.lol/v2",
     name: "adsb.lol",
     rateMs: 500,
+  },
+  adsbfi: {
+    baseUrl: "https://opendata.adsb.fi/api",
+    name: "adsb.fi",
+    rateMs: 1_100,
   },
   airplanes: {
     baseUrl: "https://api.airplanes.live/v2",
@@ -102,6 +109,20 @@ function validatePath(path: string): string | null {
   return null;
 }
 
+function buildUpstreamUrl(provider: ProviderKey, path: string): string {
+  const config = PROVIDERS[provider];
+
+  if (provider !== "adsbfi") return `${config.baseUrl}${path}`;
+
+  const pointMatch = path.match(POINT_PATH);
+  if (pointMatch) {
+    const [, lat, lon, radius] = pointMatch;
+    return `${config.baseUrl}/v3/lat/${lat}/lon/${lon}/dist/${radius}`;
+  }
+
+  return `${config.baseUrl}/v2${path}`;
+}
+
 // ── Handler ────────────────────────────────────────────────────────────
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
@@ -119,9 +140,13 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   const providerRaw =
     request.nextUrl.searchParams.get("provider")?.toLowerCase() ?? "adsb";
 
-  if (providerRaw !== "adsb" && providerRaw !== "airplanes") {
+  if (
+    providerRaw !== "adsb" &&
+    providerRaw !== "adsbfi" &&
+    providerRaw !== "airplanes"
+  ) {
     return NextResponse.json(
-      { error: "Invalid provider. Use 'adsb' or 'airplanes'." },
+      { error: "Invalid provider. Use 'adsb', 'adsbfi', or 'airplanes'." },
       { status: 400, headers: { "Cache-Control": "no-store" } },
     );
   }
@@ -136,7 +161,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   const timer = setTimeout(() => controller.abort(), READSB_FETCH_TIMEOUT_MS);
 
   try {
-    const upstream = await fetch(`${config.baseUrl}${path}`, {
+    const upstream = await fetch(buildUpstreamUrl(provider, path), {
       signal: controller.signal,
       headers: {
         Accept: "application/json",

--- a/src/app/api/flights/route.ts
+++ b/src/app/api/flights/route.ts
@@ -37,7 +37,7 @@ const PROVIDERS: Record<ProviderKey, ProviderConfig> = {
   adsbfi: {
     baseUrl: "https://opendata.adsb.fi/api",
     name: "adsb.fi",
-    rateMs: 1_100,
+    rateMs: 1_100, // Public API limit: 1 req/s per IP
   },
   airplanes: {
     baseUrl: "https://api.airplanes.live/v2",

--- a/src/app/api/flights/route.ts
+++ b/src/app/api/flights/route.ts
@@ -35,9 +35,12 @@ const PROVIDERS: Record<ProviderKey, ProviderConfig> = {
   airplanes: {
     baseUrl: "https://api.airplanes.live/v2",
     name: "airplanes.live",
-    rateMs: 1_100, // 1 req/s documented limit + 100ms margin
+    rateMs: 1_100, // Conservative best-effort floor; no published 2.0.0 quota
   },
 };
+
+const UPSTREAM_USER_AGENT =
+  "AerisFlightTracker/0.8.8 (+https://github.com/kewonit/aeris)";
 
 // ── Server-Side Rate Limiter (per provider, concurrency-safe) ──────────
 
@@ -72,17 +75,42 @@ async function enforceRateLimit(provider: ProviderKey): Promise<void> {
  * - /hex/{hex}                   - 6-char lowercase hex ICAO address
  * - /callsign/{callsign}        - alphanumeric callsign
  */
-const VALID_PATH =
-  /^\/(?:point\/-?\d+(?:\.\d+)?\/-?\d+(?:\.\d+)?\/\d{1,3}|hex\/[0-9a-f]{6}|callsign\/[A-Z0-9-]{1,8})$/i;
+const LOOKUP_PATH = /^\/(?:hex\/[0-9a-f]{6}|callsign\/[A-Z0-9-]{1,8})$/i;
+const POINT_PATH =
+  /^\/point\/(-?\d+(?:\.\d+)?)\/(-?\d+(?:\.\d+)?)\/(\d+(?:\.\d+)?)$/;
+
+function validatePath(path: string): string | null {
+  if (LOOKUP_PATH.test(path)) return null;
+
+  const pointMatch = path.match(POINT_PATH);
+  if (!pointMatch) return "Invalid or missing 'path' parameter";
+
+  const lat = Number(pointMatch[1]);
+  const lon = Number(pointMatch[2]);
+  const radius = Number(pointMatch[3]);
+
+  if (!Number.isFinite(lat) || lat < -90 || lat > 90) {
+    return "Latitude must be between -90 and 90";
+  }
+  if (!Number.isFinite(lon) || lon < -180 || lon > 180) {
+    return "Longitude must be between -180 and 180";
+  }
+  if (!Number.isFinite(radius) || radius < 0 || radius > MAX_RADIUS_NM) {
+    return `Radius must be between 0 and ${MAX_RADIUS_NM} NM`;
+  }
+
+  return null;
+}
 
 // ── Handler ────────────────────────────────────────────────────────────
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const path = request.nextUrl.searchParams.get("path")?.trim();
 
-  if (!path || !VALID_PATH.test(path)) {
+  const pathError = path ? validatePath(path) : "Invalid or missing 'path' parameter";
+  if (!path || pathError) {
     return NextResponse.json(
-      { error: "Invalid or missing 'path' parameter" },
+      { error: pathError },
       { status: 400, headers: { "Cache-Control": "no-store" } },
     );
   }
@@ -101,15 +129,6 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   const provider: ProviderKey = providerRaw;
   const config = PROVIDERS[provider];
 
-  // Validate radius for /point endpoints against max allowed
-  const pointMatch = path.match(/^\/point\/[^/]+\/[^/]+\/(\d+)$/);
-  if (pointMatch && parseInt(pointMatch[1], 10) > MAX_RADIUS_NM) {
-    return NextResponse.json(
-      { error: `Radius exceeds maximum of ${MAX_RADIUS_NM} NM` },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
-  }
-
   // Enforce server-side rate limit for this provider
   await enforceRateLimit(provider);
 
@@ -119,7 +138,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
     const upstream = await fetch(`${config.baseUrl}${path}`, {
       signal: controller.signal,
-      headers: { Accept: "application/json" },
+      headers: {
+        Accept: "application/json",
+        "User-Agent": UPSTREAM_USER_AGENT,
+      },
     });
 
     clearTimeout(timer);

--- a/src/components/flight-tracker.tsx
+++ b/src/components/flight-tracker.tsx
@@ -560,8 +560,7 @@ function FlightTrackerInner({
           if (result.flight) break;
         }
 
-        // Phase 2: For 6-char hex-like queries, also try the opposite endpoint
-        // of what the variants already attempted.
+        // Phase 2: A 6-char hex query may also be a callsign.
         if (!result.flight && !controller.signal.aborted) {
           const isHex = /^[0-9a-f]{6}$/i.test(compactQuery);
           if (isHex) {
@@ -570,9 +569,6 @@ function FlightTrackerInner({
               compactQuery.toUpperCase(),
               controller.signal,
             );
-          } else {
-            // Variants already tried callsign; try raw hex as last resort
-            result = await fetchFlightByHex(compactQuery, controller.signal);
           }
         }
 

--- a/src/components/ui/control-panel-settings.tsx
+++ b/src/components/ui/control-panel-settings.tsx
@@ -627,12 +627,17 @@ const CHANGELOG: {
       {
         title: "Consistent provider fallback",
         description:
-          "Map polling, flight lookup, FPV monitoring, and global search now share the adsb.lol, airplanes.live, and OpenSky fallback order. Provider-specific search caching and point-only sticky selection prevent one-off lookups from changing the live map source.",
+          "Map polling, flight lookup, FPV monitoring, and global search now share the adsb.lol, adsb.fi, airplanes.live, and OpenSky fallback order. Provider-specific search caching and point-only sticky selection prevent one-off lookups from changing the live map source.",
       },
       {
         title: "Production provider controls",
         description:
-          "airplanes.live is now selectable in production through the server proxy. Access denials open the provider circuit immediately, failed requests preserve last-known aircraft, and unavailable providers are reported clearly.",
+          "airplanes.live and adsb.fi are now selectable in production through the server proxy. Access denials open the provider circuit immediately, failed requests preserve last-known aircraft, and unavailable providers are reported clearly.",
+      },
+      {
+        title: "adsb.fi public fallback",
+        description:
+          "Added the adsb.fi open-data API with its v3 point-query format, conservative request pacing, shared readsb parsing, provider controls, and required linked attribution.",
       },
     ],
   },
@@ -937,9 +942,9 @@ export function AboutContent() {
         <div className="space-y-3 text-[13px] leading-relaxed text-foreground/55">
           <p>
             Live flight tracking in 3D. The planes you see are real. Position
-            data comes from airplanes.live, adsb.lol, and OpenSky Network,
-            updated every few seconds via ADS-B receivers people run on their
-            roofs worldwide.
+            data comes from adsb.lol, adsb.fi, airplanes.live, and OpenSky
+            Network, updated every few seconds via ADS-B receivers people run
+            on their roofs worldwide.
           </p>
           <p>
             You can search through 9,000+ airports, jump into first-person view

--- a/src/components/ui/control-panel-settings.tsx
+++ b/src/components/ui/control-panel-settings.tsx
@@ -637,7 +637,12 @@ const CHANGELOG: {
       {
         title: "adsb.fi public fallback",
         description:
-          "Added the adsb.fi open-data API with its v3 point-query format, conservative request pacing, shared readsb parsing, provider controls, and required linked attribution.",
+          "Added the adsb.fi open-data API with its v3 point-query format, one-request-per-second pacing, shared readsb parsing, provider controls, and required linked attribution for personal, non-commercial use.",
+      },
+      {
+        title: "Immediate provider switching",
+        description:
+          "Changing providers now cancels the previous request and refreshes the map immediately instead of waiting for the next polling cycle. Last-known aircraft remain visible while the selected provider responds.",
       },
     ],
   },

--- a/src/components/ui/control-panel-settings.tsx
+++ b/src/components/ui/control-panel-settings.tsx
@@ -616,6 +616,38 @@ const CHANGELOG: {
   entries: { title: string; description: string }[];
 }[] = [
   {
+    version: "0.8.8",
+    date: "Aug 23, 2026",
+    entries: [
+      {
+        title: "airplanes.live API 2.0.0 compatibility",
+        description:
+          "Updated readsb response handling for the airplanes.live 2.0.0 contract, including optional timing and aircraft fields, stricter validation, stale-position filtering, and support for point-query distance and direction values.",
+      },
+      {
+        title: "Consistent provider fallback",
+        description:
+          "Map polling, flight lookup, FPV monitoring, and global search now share the adsb.lol, airplanes.live, and OpenSky fallback order. Provider-specific search caching and point-only sticky selection prevent one-off lookups from changing the live map source.",
+      },
+      {
+        title: "Production provider controls",
+        description:
+          "airplanes.live is now selectable in production through the server proxy. Access denials open the provider circuit immediately, failed requests preserve last-known aircraft, and unavailable providers are reported clearly.",
+      },
+    ],
+  },
+  {
+    version: "0.8.7",
+    date: "Jul 18, 2026",
+    entries: [
+      {
+        title: "Web app identity and discovery",
+        description:
+          "Added complete favicon and install-icon sets, expanded manifest metadata, and improved canonical city pages, structured data, sitemap output, and social previews.",
+      },
+    ],
+  },
+  {
     version: "0.8.6",
     date: "Jul 11, 2026",
     entries: [
@@ -904,8 +936,8 @@ export function AboutContent() {
 
         <div className="space-y-3 text-[13px] leading-relaxed text-foreground/55">
           <p>
-            Live flight tracking in 3D. The planes you see are real — position
-            data comes from ADS-B Exchange, adsb.lol, and OpenSky Network,
+            Live flight tracking in 3D. The planes you see are real. Position
+            data comes from airplanes.live, adsb.lol, and OpenSky Network,
             updated every few seconds via ADS-B receivers people run on their
             roofs worldwide.
           </p>

--- a/src/components/ui/map-attribution.tsx
+++ b/src/components/ui/map-attribution.tsx
@@ -145,7 +145,10 @@ function ExpandedAttribution({
             )}
           </span>
         ))}
-        <span className="ml-0.5" style={{ color: "rgb(var(--ui-fg) / 0.15)" }}>
+        <span
+          className="ml-0.5"
+          style={{ color: "rgb(var(--ui-fg) / 0.15)" }}
+        >
           ·
         </span>
         <a
@@ -156,6 +159,18 @@ function ExpandedAttribution({
           style={{ color: "rgb(var(--ui-fg) / 0.4)" }}
         >
           OpenSky Network
+        </a>
+        <span className="ml-0.5" style={{ color: "rgb(var(--ui-fg) / 0.15)" }}>
+          ·
+        </span>
+        <a
+          href="https://adsb.fi/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="transition-colors hover:underline"
+          style={{ color: "rgb(var(--ui-fg) / 0.4)" }}
+        >
+          adsb.fi
         </a>
       </span>
     </motion.div>

--- a/src/components/ui/provider-panel.tsx
+++ b/src/components/ui/provider-panel.tsx
@@ -6,6 +6,7 @@ import { Satellite, X, ChevronUp, Circle } from "lucide-react";
 import {
   getCircuitState,
   getProviderOverride,
+  setProviderOverride,
   type CircuitState,
 } from "@/lib/flight-api-client";
 import type { ProviderName } from "@/lib/flight-api";
@@ -22,6 +23,11 @@ interface ProviderInfo {
 const PROVIDERS: ProviderInfo[] = [
   { id: "adsb", label: "adsb.lol", description: "Primary - server proxy" },
   {
+    id: "adsbfi",
+    label: "adsb.fi",
+    description: "Public fallback - server proxy",
+  },
+  {
     id: "airplanes",
     label: "Airplanes.live",
     description: "Fallback - server proxy",
@@ -35,6 +41,7 @@ const PROVIDERS: ProviderInfo[] = [
 
 const SOURCE_LABELS: Record<string, string> = {
   adsb: "adsb.lol",
+  adsbfi: "adsb.fi",
   opensky: "OpenSky",
   airplanes: "Airplanes.live",
   none: "Unavailable",
@@ -42,6 +49,7 @@ const SOURCE_LABELS: Record<string, string> = {
 
 const SOURCE_COLORS: Record<string, string> = {
   adsb: "rgb(52, 211, 153)", // emerald
+  adsbfi: "rgb(34, 211, 238)", // cyan
   opensky: "rgb(251, 191, 36)", // amber
   airplanes: "rgb(96, 165, 250)", // blue
   none: "rgb(248, 113, 113)", // red
@@ -62,16 +70,6 @@ function circuitBadge(
     case "half-open":
       return { label: "PROBING", color: "rgb(251, 191, 36)" };
   }
-}
-
-function setProviderOverride(provider: ProviderName | "auto"): void {
-  const url = new URL(window.location.href);
-  if (provider === "auto") {
-    url.searchParams.delete("provider");
-  } else {
-    url.searchParams.set("provider", provider);
-  }
-  window.history.replaceState({}, "", url.toString());
 }
 
 // ── Provider Dropdown ──────────────────────────────────────────────────
@@ -298,9 +296,11 @@ export function ProviderTrigger({
       ? "text-red-400/80"
       : source === "opensky"
         ? "text-amber-400/80"
-        : source === "airplanes"
-          ? "text-blue-400/80"
-          : "text-emerald-400/80";
+        : source === "adsbfi"
+          ? "text-cyan-400/80"
+          : source === "airplanes"
+            ? "text-blue-400/80"
+            : "text-emerald-400/80";
 
   return (
     <button

--- a/src/components/ui/provider-panel.tsx
+++ b/src/components/ui/provider-panel.tsx
@@ -22,14 +22,14 @@ interface ProviderInfo {
 const PROVIDERS: ProviderInfo[] = [
   { id: "adsb", label: "adsb.lol", description: "Primary - server proxy" },
   {
-    id: "opensky",
-    label: "OpenSky",
-    description: "Fallback - limited credits",
-  },
-  {
     id: "airplanes",
     label: "Airplanes.live",
-    description: "Direct - CORS restricted",
+    description: "Fallback - server proxy",
+  },
+  {
+    id: "opensky",
+    label: "OpenSky",
+    description: "Last resort - limited credits",
   },
 ];
 
@@ -92,10 +92,6 @@ export function ProviderDropdown({
 
   const [override, setOverride] = useState(() => getProviderOverride());
   const isAutoMode = override === "auto";
-  const isDev =
-    typeof window !== "undefined" &&
-    (window.location.hostname === "localhost" ||
-      window.location.hostname === "127.0.0.1");
 
   const handleSelect = useCallback(
     (provider: ProviderName | "auto") => {
@@ -207,20 +203,15 @@ export function ProviderDropdown({
                 circuit.state,
                 circuit.cooldownRemaining,
               );
-              const isAvailable = provider.id !== "airplanes" || isDev;
-
               return (
                 <button
                   key={provider.id}
                   type="button"
-                  onClick={() => isAvailable && handleSelect(provider.id)}
-                  disabled={!isAvailable}
+                  onClick={() => handleSelect(provider.id)}
                   className={`group flex w-full items-center gap-2.5 px-3.5 py-2 transition-colors ${
                     isSelected
                       ? "bg-foreground/6"
-                      : isAvailable
-                        ? "hover:bg-foreground/3 active:bg-foreground/6"
-                        : "cursor-not-allowed opacity-40"
+                      : "hover:bg-foreground/3 active:bg-foreground/6"
                   }`}
                 >
                   <div className="flex h-4 w-4 shrink-0 items-center justify-center">
@@ -256,21 +247,17 @@ export function ProviderDropdown({
                       className="text-[9px] leading-snug"
                       style={{ color: "rgb(var(--ui-fg) / 0.25)" }}
                     >
-                      {!isAvailable
-                        ? "CORS restricted - dev only"
-                        : provider.description}
+                      {provider.description}
                     </span>
                   </div>
                   <span
                     className="shrink-0 rounded px-1.5 py-px text-[8px] font-bold tracking-wider"
                     style={{
                       backgroundColor: `${badge.color}12`,
-                      color: isAvailable
-                        ? badge.color
-                        : "rgb(var(--ui-fg) / 0.25)",
+                      color: badge.color,
                     }}
                   >
-                    {isAvailable ? badge.label : "CORS"}
+                    {badge.label}
                   </span>
                 </button>
               );

--- a/src/hooks/use-flights.ts
+++ b/src/hooks/use-flights.ts
@@ -2,7 +2,10 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import type { FlightState } from "@/lib/opensky";
-import { fetchFlightsByPoint } from "@/lib/flight-api";
+import {
+  fetchFlightsByPoint,
+  PROVIDER_CHANGE_EVENT,
+} from "@/lib/flight-api";
 import type { City } from "@/lib/cities";
 
 /** Normal polling interval - readsb allows 1 req/s; 5s gives 2× data density at 0.2 req/s. */
@@ -27,7 +30,7 @@ const FPV_POINT_RADIUS = 2;
 const MAX_EMPTY_STREAK = 3;
 
 /**
- * Fetches flights via adsb.lol → airplanes.live → OpenSky fallback.
+ * Fetches flights via adsb.lol → adsb.fi → airplanes.live → OpenSky fallback.
  * In FPV mode the query center moves with the tracked aircraft.
  * City changes are ignored while in FPV.
  */
@@ -232,7 +235,7 @@ export function useFlights(
         setError(err instanceof Error ? err.message : "Unknown error");
         scheduleNext(target, RATE_LIMIT_BACKOFF_MS);
       } finally {
-        setLoading(false);
+        if (abortRef.current === controller) setLoading(false);
       }
     },
     [scheduleNext, startCountdown, clearCountdown],
@@ -318,6 +321,23 @@ export function useFlights(
       clearCountdown();
     };
   }, [city, fetchData, clearCountdown, clearSchedule, stopCountdown]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !city) return;
+
+    const activeCity = city;
+    const onProviderChange = () => {
+      clearSchedule();
+      clearCountdown();
+      setRateLimited(false);
+      emptyStreakRef.current = 0;
+      void fetchData(activeCity);
+    };
+
+    window.addEventListener(PROVIDER_CHANGE_EVENT, onProviderChange);
+    return () =>
+      window.removeEventListener(PROVIDER_CHANGE_EVENT, onProviderChange);
+  }, [city, fetchData, clearCountdown, clearSchedule]);
 
   const prevFpvRef = useRef<string | null>(fpvIcao24);
   useEffect(() => {

--- a/src/hooks/use-flights.ts
+++ b/src/hooks/use-flights.ts
@@ -27,7 +27,7 @@ const FPV_POINT_RADIUS = 2;
 const MAX_EMPTY_STREAK = 3;
 
 /**
- * Fetches flights via readsb (Airplanes.live → adsb.lol fallback).
+ * Fetches flights via adsb.lol → airplanes.live → OpenSky fallback.
  * In FPV mode the query center moves with the tracked aircraft.
  * City changes are ignored while in FPV.
  */
@@ -228,6 +228,7 @@ export function useFlights(
       } catch (err) {
         const isAbort = err instanceof Error && err.name === "AbortError";
         if (isAbort) return;
+        setSource("none");
         setError(err instanceof Error ? err.message : "Unknown error");
         scheduleNext(target, RATE_LIMIT_BACKOFF_MS);
       } finally {

--- a/src/lib/flight-api-client.test.ts
+++ b/src/lib/flight-api-client.test.ts
@@ -1,0 +1,286 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  fetchFlightByHex,
+  fetchFlightsByCallsign,
+  fetchFlightsByHex,
+  fetchFlightsByPoint,
+  getCircuitState,
+  resetAllCircuits,
+} from "./flight-api-client";
+
+function rawAircraft(hex = "abc123") {
+  return {
+    hex,
+    type: "adsb_icao",
+    flight: "TST123 ",
+    lat: 12.5,
+    lon: 77.6,
+    alt_baro: 30_000,
+    seen_pos: 0.2,
+  };
+}
+
+function readsbResponse(ac: unknown[], status = 200): Response {
+  return Response.json(
+    { ac, msg: "No error", now: Date.now(), total: ac.length },
+    { status },
+  );
+}
+
+function openskyResponse(hex = "abc123"): Response {
+  return Response.json({
+    time: 1,
+    states: [
+      [
+        hex,
+        "TST123 ",
+        "Unknown",
+        1,
+        1,
+        77.6,
+        12.5,
+        9_144,
+        false,
+        220,
+        90,
+        0,
+        null,
+        9_200,
+        "1200",
+        false,
+        0,
+        3,
+      ],
+    ],
+  });
+}
+
+function restoreWindow(descriptor: PropertyDescriptor | undefined): void {
+  if (descriptor) {
+    Object.defineProperty(globalThis, "window", descriptor);
+  } else {
+    delete (globalThis as typeof globalThis & { window?: unknown }).window;
+  }
+}
+
+test("adsb.lol success short-circuits point fallback", async () => {
+  resetAllCircuits();
+  const calls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: RequestInfo | URL) => {
+    calls.push(input.toString());
+    return readsbResponse([rawAircraft()]);
+  };
+
+  try {
+    const result = await fetchFlightsByPoint(12.5, 77.6, 1);
+    assert.equal(result.source, "adsb");
+    assert.equal(result.flights.length, 1);
+    assert.equal(calls.length, 1);
+    assert.match(calls[0], /provider=adsb/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("a valid empty point response does not trigger fallback", async () => {
+  resetAllCircuits();
+  const calls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: RequestInfo | URL) => {
+    calls.push(input.toString());
+    return readsbResponse([]);
+  };
+
+  try {
+    const result = await fetchFlightsByPoint(12.5, 77.6, 1);
+    assert.deepEqual(result.flights, []);
+    assert.equal(result.source, "adsb");
+    assert.equal(calls.length, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("an empty hex lookup continues from adsb.lol to airplanes.live", async () => {
+  resetAllCircuits();
+  const calls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: RequestInfo | URL) => {
+    const url = input.toString();
+    calls.push(url);
+    return url.includes("provider=adsb")
+      ? readsbResponse([])
+      : readsbResponse([rawAircraft()]);
+  };
+
+  try {
+    const result = await fetchFlightsByHex("abc123");
+    assert.equal(result.source, "airplanes");
+    assert.equal(result.flights.length, 1);
+    assert.equal(calls.length, 2);
+    assert.match(calls[0], /provider=adsb/);
+    assert.match(calls[1], /provider=airplanes/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("OpenSky takes over a hex lookup after both readsb providers fail", async () => {
+  resetAllCircuits();
+  const calls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: RequestInfo | URL) => {
+    const url = input.toString();
+    calls.push(url);
+    return url.startsWith("/api/flights")
+      ? new Response(null, { status: 502 })
+      : openskyResponse();
+  };
+
+  try {
+    const result = await fetchFlightsByHex("abc123");
+    assert.equal(result.source, "opensky");
+    assert.equal(result.flights[0]?.icao24, "abc123");
+    assert.equal(calls.length, 3);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("OpenSky takes over a callsign lookup after both readsb providers fail", async () => {
+  resetAllCircuits();
+  const calls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: RequestInfo | URL) => {
+    const url = input.toString();
+    calls.push(url);
+    return url.startsWith("/api/flights")
+      ? new Response(null, { status: 502 })
+      : openskyResponse();
+  };
+
+  try {
+    const result = await fetchFlightsByCallsign("TST123");
+    assert.equal(result.source, "opensky");
+    assert.equal(result.flights[0]?.callsign, "TST123");
+    assert.equal(calls.length, 3);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("explicit airplanes.live override stays pinned", async () => {
+  resetAllCircuits();
+  const originalFetch = globalThis.fetch;
+  const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const calls: string[] = [];
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      location: { search: "?provider=airplanes" },
+      addEventListener: () => {},
+    },
+  });
+  globalThis.fetch = async (input: RequestInfo | URL) => {
+    calls.push(input.toString());
+    return readsbResponse([rawAircraft()]);
+  };
+
+  try {
+    const result = await fetchFlightsByPoint(12.5, 77.6, 1);
+    assert.equal(result.source, "airplanes");
+    assert.equal(calls.length, 1);
+    assert.match(calls[0], /provider=airplanes/);
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreWindow(originalWindow);
+  }
+});
+
+test("401 and 403 open a provider circuit immediately for five minutes", async () => {
+  for (const status of [401, 403]) {
+    resetAllCircuits();
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input: RequestInfo | URL) =>
+      input.toString().includes("provider=adsb")
+        ? new Response(null, { status })
+        : readsbResponse([rawAircraft()]);
+
+    try {
+      await fetchFlightsByPoint(12.5, 77.6, 1);
+      const circuit = getCircuitState("adsb");
+      assert.equal(circuit.state, "open");
+      assert.ok(circuit.cooldownRemaining > 299_000);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  }
+});
+
+test("429 remains rate limiting and does not open the circuit", async () => {
+  resetAllCircuits();
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: RequestInfo | URL) =>
+    input.toString().includes("provider=adsb")
+      ? new Response(null, { status: 429 })
+      : readsbResponse([rawAircraft()]);
+
+  try {
+    const result = await fetchFlightsByPoint(12.5, 77.6, 1);
+    assert.equal(result.source, "airplanes");
+    assert.equal(getCircuitState("adsb").state, "closed");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("one-off lookup success does not change point-polling stickiness", async () => {
+  resetAllCircuits();
+  let phase: "lookup" | "point" = "lookup";
+  const pointCalls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: RequestInfo | URL) => {
+    const url = input.toString();
+    if (phase === "lookup") {
+      return url.includes("provider=adsb")
+        ? readsbResponse([])
+        : readsbResponse([rawAircraft()]);
+    }
+    pointCalls.push(url);
+    return readsbResponse([rawAircraft()]);
+  };
+
+  try {
+    assert.ok((await fetchFlightByHex("abc123")).flight);
+    phase = "point";
+    const result = await fetchFlightsByPoint(12.5, 77.6, 1);
+    assert.equal(result.source, "adsb");
+    assert.equal(pointCalls.length, 1);
+    assert.match(pointCalls[0], /provider=adsb/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("invalid callsigns are rejected before any provider request", async () => {
+  resetAllCircuits();
+  let fetchCount = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    fetchCount++;
+    return readsbResponse([]);
+  };
+
+  try {
+    assert.deepEqual(await fetchFlightsByCallsign("TOO-LONG-123"), {
+      flights: [],
+      rateLimited: false,
+    });
+    assert.equal(fetchCount, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/src/lib/flight-api-client.test.ts
+++ b/src/lib/flight-api-client.test.ts
@@ -7,7 +7,9 @@ import {
   fetchFlightsByHex,
   fetchFlightsByPoint,
   getCircuitState,
+  PROVIDER_CHANGE_EVENT,
   resetAllCircuits,
+  setProviderOverride,
 } from "./flight-api-client";
 
 function rawAircraft(hex = "abc123") {
@@ -65,6 +67,51 @@ function restoreWindow(descriptor: PropertyDescriptor | undefined): void {
   }
 }
 
+function providerFromRequest(input: RequestInfo | URL | string): string | null {
+  return new URL(input.toString(), "http://localhost").searchParams.get(
+    "provider",
+  );
+}
+
+test("provider selection updates the URL and emits an immediate refresh event", () => {
+  const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const events: string[] = [];
+  const location = {
+    href: "https://aeris.example/city/sfo?provider=adsb",
+    search: "?provider=adsb",
+  };
+  const fakeWindow = {
+    location,
+    history: {
+      replaceState: (_state: unknown, _unused: string, href: string) => {
+        location.href = href;
+        location.search = new URL(href).search;
+      },
+    },
+    addEventListener: () => {},
+    dispatchEvent: (event: Event) => {
+      events.push(event.type);
+      return true;
+    },
+  };
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: fakeWindow,
+  });
+
+  try {
+    setProviderOverride("adsbfi");
+    assert.equal(location.search, "?provider=adsbfi");
+    assert.deepEqual(events, [PROVIDER_CHANGE_EVENT]);
+
+    setProviderOverride("auto");
+    assert.equal(location.search, "");
+    assert.deepEqual(events, [PROVIDER_CHANGE_EVENT, PROVIDER_CHANGE_EVENT]);
+  } finally {
+    restoreWindow(originalWindow);
+  }
+});
+
 test("adsb.lol success short-circuits point fallback", async () => {
   resetAllCircuits();
   const calls: string[] = [];
@@ -104,31 +151,81 @@ test("a valid empty point response does not trigger fallback", async () => {
   }
 });
 
-test("an empty hex lookup continues from adsb.lol to airplanes.live", async () => {
+test("an adsb.lol point failure falls back to adsb.fi", async () => {
   resetAllCircuits();
   const calls: string[] = [];
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (input: RequestInfo | URL) => {
     const url = input.toString();
     calls.push(url);
-    return url.includes("provider=adsb")
+    const provider = providerFromRequest(url);
+    return provider === "adsb"
+      ? new Response(null, { status: 502 })
+      : readsbResponse([rawAircraft()]);
+  };
+
+  try {
+    const result = await fetchFlightsByPoint(12.5, 77.6, 1);
+    assert.equal(result.source, "adsbfi");
+    assert.equal(result.flights.length, 1);
+    assert.equal(calls.length, 2);
+    assert.match(calls[0], /provider=adsb/);
+    assert.match(calls[1], /provider=adsbfi/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("an empty hex lookup continues from adsb.lol to adsb.fi", async () => {
+  resetAllCircuits();
+  const calls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: RequestInfo | URL) => {
+    const url = input.toString();
+    calls.push(url);
+    return providerFromRequest(url) === "adsb"
       ? readsbResponse([])
       : readsbResponse([rawAircraft()]);
   };
 
   try {
     const result = await fetchFlightsByHex("abc123");
-    assert.equal(result.source, "airplanes");
+    assert.equal(result.source, "adsbfi");
     assert.equal(result.flights.length, 1);
     assert.equal(calls.length, 2);
     assert.match(calls[0], /provider=adsb/);
-    assert.match(calls[1], /provider=airplanes/);
+    assert.match(calls[1], /provider=adsbfi/);
   } finally {
     globalThis.fetch = originalFetch;
   }
 });
 
-test("OpenSky takes over a hex lookup after both readsb providers fail", async () => {
+test("an adsb.fi lookup miss continues to airplanes.live", async () => {
+  resetAllCircuits();
+  const calls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: RequestInfo | URL) => {
+    const url = input.toString();
+    calls.push(url);
+    return url.includes("provider=airplanes")
+      ? readsbResponse([rawAircraft()])
+      : readsbResponse([]);
+  };
+
+  try {
+    const result = await fetchFlightsByHex("abc123");
+    assert.equal(result.source, "airplanes");
+    assert.equal(result.flights.length, 1);
+    assert.equal(calls.length, 3);
+    assert.match(calls[0], /provider=adsb/);
+    assert.match(calls[1], /provider=adsbfi/);
+    assert.match(calls[2], /provider=airplanes/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("OpenSky takes over a hex lookup after all readsb providers fail", async () => {
   resetAllCircuits();
   const calls: string[] = [];
   const originalFetch = globalThis.fetch;
@@ -144,13 +241,13 @@ test("OpenSky takes over a hex lookup after both readsb providers fail", async (
     const result = await fetchFlightsByHex("abc123");
     assert.equal(result.source, "opensky");
     assert.equal(result.flights[0]?.icao24, "abc123");
-    assert.equal(calls.length, 3);
+    assert.equal(calls.length, 4);
   } finally {
     globalThis.fetch = originalFetch;
   }
 });
 
-test("OpenSky takes over a callsign lookup after both readsb providers fail", async () => {
+test("OpenSky takes over a callsign lookup after all readsb providers fail", async () => {
   resetAllCircuits();
   const calls: string[] = [];
   const originalFetch = globalThis.fetch;
@@ -166,7 +263,7 @@ test("OpenSky takes over a callsign lookup after both readsb providers fail", as
     const result = await fetchFlightsByCallsign("TST123");
     assert.equal(result.source, "opensky");
     assert.equal(result.flights[0]?.callsign, "TST123");
-    assert.equal(calls.length, 3);
+    assert.equal(calls.length, 4);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -200,12 +297,40 @@ test("explicit airplanes.live override stays pinned", async () => {
   }
 });
 
+test("explicit adsb.fi override stays pinned", async () => {
+  resetAllCircuits();
+  const originalFetch = globalThis.fetch;
+  const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const calls: string[] = [];
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      location: { search: "?provider=adsbfi" },
+      addEventListener: () => {},
+    },
+  });
+  globalThis.fetch = async (input: RequestInfo | URL) => {
+    calls.push(input.toString());
+    return readsbResponse([rawAircraft()]);
+  };
+
+  try {
+    const result = await fetchFlightsByPoint(12.5, 77.6, 1);
+    assert.equal(result.source, "adsbfi");
+    assert.equal(calls.length, 1);
+    assert.match(calls[0], /provider=adsbfi/);
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreWindow(originalWindow);
+  }
+});
+
 test("401 and 403 open a provider circuit immediately for five minutes", async () => {
   for (const status of [401, 403]) {
     resetAllCircuits();
     const originalFetch = globalThis.fetch;
     globalThis.fetch = async (input: RequestInfo | URL) =>
-      input.toString().includes("provider=adsb")
+      providerFromRequest(input) === "adsb"
         ? new Response(null, { status })
         : readsbResponse([rawAircraft()]);
 
@@ -224,13 +349,13 @@ test("429 remains rate limiting and does not open the circuit", async () => {
   resetAllCircuits();
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (input: RequestInfo | URL) =>
-    input.toString().includes("provider=adsb")
+    providerFromRequest(input) === "adsb"
       ? new Response(null, { status: 429 })
       : readsbResponse([rawAircraft()]);
 
   try {
     const result = await fetchFlightsByPoint(12.5, 77.6, 1);
-    assert.equal(result.source, "airplanes");
+    assert.equal(result.source, "adsbfi");
     assert.equal(getCircuitState("adsb").state, "closed");
   } finally {
     globalThis.fetch = originalFetch;
@@ -245,7 +370,7 @@ test("one-off lookup success does not change point-polling stickiness", async ()
   globalThis.fetch = async (input: RequestInfo | URL) => {
     const url = input.toString();
     if (phase === "lookup") {
-      return url.includes("provider=adsb")
+      return providerFromRequest(url) === "adsb"
         ? readsbResponse([])
         : readsbResponse([rawAircraft()]);
     }

--- a/src/lib/flight-api-client.test.ts
+++ b/src/lib/flight-api-client.test.ts
@@ -126,7 +126,7 @@ test("adsb.lol success short-circuits point fallback", async () => {
     assert.equal(result.source, "adsb");
     assert.equal(result.flights.length, 1);
     assert.equal(calls.length, 1);
-    assert.match(calls[0], /provider=adsb/);
+    assert.equal(providerFromRequest(calls[0]), "adsb");
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -169,8 +169,8 @@ test("an adsb.lol point failure falls back to adsb.fi", async () => {
     assert.equal(result.source, "adsbfi");
     assert.equal(result.flights.length, 1);
     assert.equal(calls.length, 2);
-    assert.match(calls[0], /provider=adsb/);
-    assert.match(calls[1], /provider=adsbfi/);
+    assert.equal(providerFromRequest(calls[0]), "adsb");
+    assert.equal(providerFromRequest(calls[1]), "adsbfi");
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -193,8 +193,8 @@ test("an empty hex lookup continues from adsb.lol to adsb.fi", async () => {
     assert.equal(result.source, "adsbfi");
     assert.equal(result.flights.length, 1);
     assert.equal(calls.length, 2);
-    assert.match(calls[0], /provider=adsb/);
-    assert.match(calls[1], /provider=adsbfi/);
+    assert.equal(providerFromRequest(calls[0]), "adsb");
+    assert.equal(providerFromRequest(calls[1]), "adsbfi");
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -217,9 +217,9 @@ test("an adsb.fi lookup miss continues to airplanes.live", async () => {
     assert.equal(result.source, "airplanes");
     assert.equal(result.flights.length, 1);
     assert.equal(calls.length, 3);
-    assert.match(calls[0], /provider=adsb/);
-    assert.match(calls[1], /provider=adsbfi/);
-    assert.match(calls[2], /provider=airplanes/);
+    assert.equal(providerFromRequest(calls[0]), "adsb");
+    assert.equal(providerFromRequest(calls[1]), "adsbfi");
+    assert.equal(providerFromRequest(calls[2]), "airplanes");
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -290,7 +290,7 @@ test("explicit airplanes.live override stays pinned", async () => {
     const result = await fetchFlightsByPoint(12.5, 77.6, 1);
     assert.equal(result.source, "airplanes");
     assert.equal(calls.length, 1);
-    assert.match(calls[0], /provider=airplanes/);
+    assert.equal(providerFromRequest(calls[0]), "airplanes");
   } finally {
     globalThis.fetch = originalFetch;
     restoreWindow(originalWindow);
@@ -318,7 +318,7 @@ test("explicit adsb.fi override stays pinned", async () => {
     const result = await fetchFlightsByPoint(12.5, 77.6, 1);
     assert.equal(result.source, "adsbfi");
     assert.equal(calls.length, 1);
-    assert.match(calls[0], /provider=adsbfi/);
+    assert.equal(providerFromRequest(calls[0]), "adsbfi");
   } finally {
     globalThis.fetch = originalFetch;
     restoreWindow(originalWindow);
@@ -384,7 +384,7 @@ test("one-off lookup success does not change point-polling stickiness", async ()
     const result = await fetchFlightsByPoint(12.5, 77.6, 1);
     assert.equal(result.source, "adsb");
     assert.equal(pointCalls.length, 1);
-    assert.match(pointCalls[0], /provider=adsb/);
+    assert.equal(providerFromRequest(pointCalls[0]), "adsb");
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/src/lib/flight-api-client.ts
+++ b/src/lib/flight-api-client.ts
@@ -1,7 +1,7 @@
 // ── readsb API Client ────────────────────────────────────────────────
 //
 // 3-tier fallback: adsb.lol proxy → airplanes.live proxy → OpenSky.
-// Dev/override: ?provider=airplanes|adsb|opensky in the URL.
+// Override: ?provider=airplanes|adsb|opensky in the URL.
 // ────────────────────────────────────────────────────────────────────────
 
 import type { FlightState } from "./opensky-types";
@@ -11,6 +11,7 @@ import { parseAircraftList, type ParseOptions } from "./flight-api-parsing";
 import {
   bboxFromCenter,
   fetchFlightsByBbox,
+  fetchFlightByCallsign as openskyFetchByCallsign,
   fetchFlightByIcao24 as openskyFetchByIcao24,
 } from "./opensky-flights";
 
@@ -34,7 +35,8 @@ export interface FlightApiFetchResult {
 //   • probe fails    → OPEN (cooldown doubles, capped at 5 min)
 //
 // What counts as a failure:
-//   ✓ Timeout, HTTP 5xx, non-JSON response, network error
+//   ✓ Timeout, HTTP errors, non-JSON response, network error
+//   ✓ 401/403 immediately open the circuit for the maximum cooldown
 //   ✗ AbortError (tab switch / navigation)
 //   ✗ 429 rate-limit (server is alive, handled separately)
 // ────────────────────────────────────────────────────────────────────────
@@ -54,6 +56,22 @@ const CIRCUIT_MAX_COOLDOWN_MS = 300_000; // 5 min
 
 const circuits = new Map<string, TierCircuit>();
 
+// Sticky preference is deliberately point-polling state only. One-off
+// lookups and global searches must neither read nor update it.
+const STICKY_WINDOW_MS = 60_000; // 60 s
+let stickySource: string | null = null;
+let stickyUntil = 0;
+
+class ProviderHttpError extends Error {
+  constructor(
+    readonly provider: string,
+    readonly status: number,
+  ) {
+    super(`${provider} proxy ${status}`);
+    this.name = "ProviderHttpError";
+  }
+}
+
 function shouldSkipTier(tierId: string): boolean {
   const c = circuits.get(tierId);
   if (!c || c.state === "closed") return false;
@@ -69,12 +87,25 @@ function recordSuccess(tierId: string): void {
   circuits.set(tierId, { state: "closed", failures: 0, openUntil: 0 });
 }
 
-function recordFailure(tierId: string): void {
+function recordFailure(tierId: string, err: unknown): void {
   const c = circuits.get(tierId) ?? {
     state: "closed" as CircuitState,
     failures: 0,
     openUntil: 0,
   };
+
+  if (
+    err instanceof ProviderHttpError &&
+    (err.status === 401 || err.status === 403)
+  ) {
+    circuits.set(tierId, {
+      state: "open",
+      failures: Math.max(c.failures + 1, CIRCUIT_FAILURE_THRESHOLD),
+      openUntil: Date.now() + CIRCUIT_MAX_COOLDOWN_MS,
+    });
+    return;
+  }
+
   c.failures++;
   if (c.failures >= CIRCUIT_FAILURE_THRESHOLD) {
     // Cooldown: 60s → 120s → 240s → 300s …
@@ -92,8 +123,9 @@ function recordFailure(tierId: string): void {
 /** Returns true if this error should NOT trip the circuit breaker. */
 function isNonCircuitError(err: unknown): boolean {
   // Abort = tab switch / navigation - not a provider failure
-  if (err instanceof DOMException && err.name === "AbortError") return true;
+  if (err instanceof Error && err.name === "AbortError") return true;
   // 429 = server is alive, just rate-limiting - already handled via rateLimited flag
+  if (err instanceof ProviderHttpError && err.status === 429) return true;
   const msg =
     err instanceof Error
       ? err.message.toLowerCase()
@@ -123,6 +155,8 @@ export function getCircuitState(tierId: string): {
 /** Reset all circuits (e.g. on network reconnect). */
 export function resetAllCircuits(): void {
   circuits.clear();
+  stickySource = null;
+  stickyUntil = 0;
 }
 
 let _onlineListenerRegistered = false;
@@ -131,7 +165,7 @@ if (typeof window !== "undefined" && !_onlineListenerRegistered) {
   window.addEventListener("online", resetAllCircuits);
 }
 
-// ── Provider Override (dev testing) ────────────────────────────────────
+// ── Provider Override ──────────────────────────────────────────────────
 
 export function getProviderOverride(): ProviderName {
   if (typeof window === "undefined") return "auto";
@@ -183,21 +217,33 @@ async function withTimeout<T>(
 }
 
 function validateReadsb(payload: unknown): ReadsbApiResponse {
+  if (!payload || typeof payload !== "object") {
+    throw new Error("Invalid readsb response shape");
+  }
+
+  const response = payload as Partial<ReadsbApiResponse>;
   if (
-    !payload ||
-    typeof payload !== "object" ||
-    !Array.isArray((payload as ReadsbApiResponse).ac)
+    !Array.isArray(response.ac) ||
+    typeof response.msg !== "string" ||
+    typeof response.now !== "number" ||
+    !Number.isFinite(response.now) ||
+    typeof response.total !== "number" ||
+    !Number.isFinite(response.total) ||
+    (response.ctime !== undefined &&
+      (typeof response.ctime !== "number" || !Number.isFinite(response.ctime))) ||
+    (response.ptime !== undefined &&
+      (typeof response.ptime !== "number" || !Number.isFinite(response.ptime)))
   ) {
     throw new Error("Invalid readsb response shape");
   }
-  return payload as ReadsbApiResponse;
+
+  return response as ReadsbApiResponse;
 }
 
 // ── Tier 1 / Tier 2: readsb via server proxy ──────────────────────────
 //
 // Server proxy supports ?provider=adsb|airplanes.
-// Airplanes.live is Tier 1 (richest data: registration, type, description).
-// adsb.lol is Tier 2 (community-run, generous limits).
+// adsb.lol is primary; airplanes.live is the best-effort secondary provider.
 
 async function fetchViaProxy(
   path: string,
@@ -209,7 +255,7 @@ async function fetchViaProxy(
       const url = `/api/flights?path=${encodeURIComponent(path)}&provider=${provider}`;
       const res = await fetch(url, { cache: "no-store", signal: innerSignal });
 
-      if (!res.ok) throw new Error(`${provider} proxy ${res.status}`);
+      if (!res.ok) throw new ProviderHttpError(provider, res.status);
 
       const ct = res.headers.get("content-type") ?? "";
       if (ct.includes("text/html") || ct.includes("text/xml")) {
@@ -244,33 +290,30 @@ interface NamedTier {
   fn: () => Promise<FlightState[]>;
 }
 
-// ── Sticky Source ──────────────────────────────────────────────────────
-//
-// After a provider succeeds, prefer it for STICKY_WINDOW_MS before
-// trying higher-priority tiers again. This prevents unnecessary
-// flip-flopping between providers when both are healthy.
-
-const STICKY_WINDOW_MS = 60_000; // 60 s
-let stickySource: string | null = null;
-let stickyUntil = 0;
-
 function recordStickySuccess(tierId: string): void {
   stickySource = tierId;
   stickyUntil = Date.now() + STICKY_WINDOW_MS;
 }
 
+interface FallbackOptions {
+  /** A valid empty lookup is a miss, so continue to the next provider. */
+  continueOnEmpty?: boolean;
+  /** Only continuous point polling may use or update sticky preference. */
+  usePointSticky?: boolean;
+}
+
 async function runFallbackChain(
   tiers: NamedTier[],
   signal?: AbortSignal,
+  options?: FallbackOptions,
 ): Promise<FlightApiFetchResult> {
   let lastError: Error | null = null;
   let allSkipped = true;
   let lastTriedId: string | undefined;
+  let lastEmptySource: string | undefined;
 
-  // If we have a sticky source and it's still within the window,
-  // try it first before the normal tier order.
   const orderedTiers =
-    stickySource && Date.now() < stickyUntil
+    options?.usePointSticky && stickySource && Date.now() < stickyUntil
       ? [
           ...tiers.filter((t) => t.id === stickySource),
           ...tiers.filter((t) => t.id !== stickySource),
@@ -285,16 +328,26 @@ async function runFallbackChain(
     try {
       const flights = await fn();
       recordSuccess(id);
-      recordStickySuccess(id);
+
+      if (options?.continueOnEmpty && flights.length === 0) {
+        lastEmptySource = id;
+        continue;
+      }
+
+      if (options?.usePointSticky) recordStickySuccess(id);
       return { flights, rateLimited: false, source: id };
     } catch (err) {
       if (signal?.aborted) throw err;
-      if (err instanceof DOMException && err.name === "AbortError") throw err;
+      if (err instanceof Error && err.name === "AbortError") throw err;
 
-      if (!isNonCircuitError(err)) recordFailure(id);
+      if (!isNonCircuitError(err)) recordFailure(id, err);
 
       lastError = err instanceof Error ? err : new Error(String(err));
     }
+  }
+
+  if (lastEmptySource) {
+    return { flights: [], rateLimited: false, source: lastEmptySource };
   }
 
   if (allSkipped) {
@@ -371,20 +424,20 @@ export async function fetchFlightsByPoint(
     });
   }
 
-  return runFallbackChain(tiers, signal);
+  return runFallbackChain(tiers, signal, { usePointSticky: true });
 }
 
 /**
- * Fetch a single aircraft by ICAO24 hex address.
+ * Fetch all aircraft returned for an ICAO24 hex address.
  * Uses the fallback chain: adsb.lol proxy → airplanes.live proxy → OpenSky.
  */
-export async function fetchFlightByHex(
+export async function fetchFlightsByHex(
   icao24: string,
   signal?: AbortSignal,
-): Promise<{ flight: FlightState | null }> {
+): Promise<FlightApiFetchResult> {
   const normalized = icao24.trim().toLowerCase();
   if (!/^[0-9a-f]{6}$/i.test(normalized)) {
-    return { flight: null };
+    return { flights: [], rateLimited: false };
   }
 
   const parseOpts: ParseOptions = {
@@ -439,23 +492,24 @@ export async function fetchFlightByHex(
   }
 
   try {
-    const result = await runFallbackChain(tiers, signal);
-    return { flight: result.flights[0] ?? null };
+    return await runFallbackChain(tiers, signal, { continueOnEmpty: true });
   } catch {
-    return { flight: null };
+    return { flights: [], rateLimited: false };
   }
 }
 
 /**
- * Fetch flights matching a callsign.
- * No OpenSky tier: callsign search queries all aircraft (4-credit global fetch).
+ * Fetch all aircraft matching a callsign.
+ * Uses OpenSky only after both readsb providers miss or fail.
  */
-export async function fetchFlightByCallsign(
+export async function fetchFlightsByCallsign(
   callsign: string,
   signal?: AbortSignal,
-): Promise<{ flight: FlightState | null }> {
+): Promise<FlightApiFetchResult> {
   const normalized = callsign.trim().toUpperCase();
-  if (!normalized) return { flight: null };
+  if (!/^[A-Z0-9-]{1,8}$/.test(normalized)) {
+    return { flights: [], rateLimited: false };
+  }
 
   const parseOpts: ParseOptions = {
     includeGround: true,
@@ -487,12 +541,38 @@ export async function fetchFlightByCallsign(
     });
   }
 
-  // No OpenSky tier: callsign search queries all aircraft (4-credit global fetch)
+  if (override === "auto" || override === "opensky") {
+    tiers.push({
+      id: "opensky",
+      fn: async () => {
+        const result = await openskyFetchByCallsign(normalized, signal);
+        if (result.rateLimited) throw new Error("OpenSky rate limited (429)");
+        return result.flight ? [result.flight] : [];
+      },
+    });
+  }
 
   try {
-    const result = await runFallbackChain(tiers, signal);
-    return { flight: result.flights[0] ?? null };
+    return await runFallbackChain(tiers, signal, { continueOnEmpty: true });
   } catch {
-    return { flight: null };
+    return { flights: [], rateLimited: false };
   }
+}
+
+/** Fetch a single aircraft by ICAO24 while preserving the existing API. */
+export async function fetchFlightByHex(
+  icao24: string,
+  signal?: AbortSignal,
+): Promise<{ flight: FlightState | null }> {
+  const result = await fetchFlightsByHex(icao24, signal);
+  return { flight: result.flights[0] ?? null };
+}
+
+/** Fetch a single aircraft by callsign while preserving the existing API. */
+export async function fetchFlightByCallsign(
+  callsign: string,
+  signal?: AbortSignal,
+): Promise<{ flight: FlightState | null }> {
+  const result = await fetchFlightsByCallsign(callsign, signal);
+  return { flight: result.flights[0] ?? null };
 }

--- a/src/lib/flight-api-client.ts
+++ b/src/lib/flight-api-client.ts
@@ -1,7 +1,7 @@
 // ── readsb API Client ────────────────────────────────────────────────
 //
-// 3-tier fallback: adsb.lol proxy → airplanes.live proxy → OpenSky.
-// Override: ?provider=airplanes|adsb|opensky in the URL.
+// 4-tier fallback: adsb.lol proxy → adsb.fi proxy → airplanes.live proxy → OpenSky.
+// Override: ?provider=airplanes|adsb|adsbfi|opensky in the URL.
 // ────────────────────────────────────────────────────────────────────────
 
 import type { FlightState } from "./opensky-types";
@@ -17,7 +17,14 @@ import {
 
 // ── Types ──────────────────────────────────────────────────────────────
 
-export type ProviderName = "airplanes" | "adsb" | "opensky" | "auto";
+export type ProviderName =
+  | "airplanes"
+  | "adsb"
+  | "adsbfi"
+  | "opensky"
+  | "auto";
+
+export const PROVIDER_CHANGE_EVENT = "aeris:provider-change";
 
 export interface FlightApiFetchResult {
   flights: FlightState[];
@@ -172,8 +179,30 @@ export function getProviderOverride(): ProviderName {
   const p = new URLSearchParams(window.location.search)
     .get("provider")
     ?.toLowerCase();
-  if (p === "airplanes" || p === "adsb" || p === "opensky") return p;
+  if (
+    p === "airplanes" ||
+    p === "adsb" ||
+    p === "adsbfi" ||
+    p === "opensky"
+  )
+    return p;
   return "auto";
+}
+
+export function setProviderOverride(provider: ProviderName): void {
+  if (typeof window === "undefined") return;
+
+  const url = new URL(window.location.href);
+  if (provider === "auto") {
+    url.searchParams.delete("provider");
+  } else {
+    url.searchParams.set("provider", provider);
+  }
+
+  stickySource = null;
+  stickyUntil = 0;
+  window.history.replaceState({}, "", url.toString());
+  window.dispatchEvent(new Event(PROVIDER_CHANGE_EVENT));
 }
 
 // ── Constants ──────────────────────────────────────────────────────────
@@ -240,14 +269,14 @@ function validateReadsb(payload: unknown): ReadsbApiResponse {
   return response as ReadsbApiResponse;
 }
 
-// ── Tier 1 / Tier 2: readsb via server proxy ──────────────────────────
+// ── readsb providers via server proxy ─────────────────────────────────
 //
-// Server proxy supports ?provider=adsb|airplanes.
-// adsb.lol is primary; airplanes.live is the best-effort secondary provider.
+// Server proxy supports ?provider=adsb|adsbfi|airplanes.
+// adsb.lol is primary; adsb.fi and airplanes.live are fallbacks.
 
 async function fetchViaProxy(
   path: string,
-  provider: "adsb" | "airplanes" = "adsb",
+  provider: "adsb" | "adsbfi" | "airplanes" = "adsb",
   signal?: AbortSignal,
 ): Promise<ReadsbApiResponse> {
   return withTimeout(
@@ -269,7 +298,7 @@ async function fetchViaProxy(
   );
 }
 
-// ── Tier 3: OpenSky direct ─────────────────────────────────────────────
+// ── Tier 4: OpenSky direct ─────────────────────────────────────────────
 
 async function fetchFromOpenSkyPoint(
   lat: number,
@@ -366,7 +395,7 @@ async function runFallbackChain(
 
 /**
  * Fetch flights within a radius of a geographic point.
- * Uses the fallback chain: adsb.lol proxy → airplanes.live proxy → OpenSky.
+ * Uses the fallback chain: adsb.lol proxy → adsb.fi proxy → airplanes.live proxy → OpenSky.
  */
 export async function fetchFlightsByPoint(
   lat: number,
@@ -393,6 +422,17 @@ export async function fetchFlightsByPoint(
       id: "adsb",
       fn: async () => {
         const resp = await fetchViaProxy(readsbPath, "adsb", signal);
+        return parseAircraftList(resp.ac, options);
+      },
+    });
+  }
+
+  if (override === "adsbfi" || override === "auto") {
+    // adsb.fi via proxy - public secondary fallback
+    tiers.push({
+      id: "adsbfi",
+      fn: async () => {
+        const resp = await fetchViaProxy(readsbPath, "adsbfi", signal);
         return parseAircraftList(resp.ac, options);
       },
     });
@@ -429,7 +469,7 @@ export async function fetchFlightsByPoint(
 
 /**
  * Fetch all aircraft returned for an ICAO24 hex address.
- * Uses the fallback chain: adsb.lol proxy → airplanes.live proxy → OpenSky.
+ * Uses the fallback chain: adsb.lol proxy → adsb.fi proxy → airplanes.live proxy → OpenSky.
  */
 export async function fetchFlightsByHex(
   icao24: string,
@@ -454,6 +494,17 @@ export async function fetchFlightsByHex(
       id: "adsb",
       fn: async () => {
         const resp = await fetchViaProxy(readsbPath, "adsb", signal);
+        return parseAircraftList(resp.ac, parseOpts);
+      },
+    });
+  }
+
+  if (override === "adsbfi" || override === "auto") {
+    // adsb.fi via proxy - public secondary fallback
+    tiers.push({
+      id: "adsbfi",
+      fn: async () => {
+        const resp = await fetchViaProxy(readsbPath, "adsbfi", signal);
         return parseAircraftList(resp.ac, parseOpts);
       },
     });
@@ -500,7 +551,7 @@ export async function fetchFlightsByHex(
 
 /**
  * Fetch all aircraft matching a callsign.
- * Uses OpenSky only after both readsb providers miss or fail.
+ * Uses OpenSky only after all readsb providers miss or fail.
  */
 export async function fetchFlightsByCallsign(
   callsign: string,
@@ -525,6 +576,17 @@ export async function fetchFlightsByCallsign(
       id: "adsb",
       fn: async () => {
         const resp = await fetchViaProxy(readsbPath, "adsb", signal);
+        return parseAircraftList(resp.ac, parseOpts);
+      },
+    });
+  }
+
+  if (override === "adsbfi" || override === "auto") {
+    // adsb.fi via proxy - public secondary fallback
+    tiers.push({
+      id: "adsbfi",
+      fn: async () => {
+        const resp = await fetchViaProxy(readsbPath, "adsbfi", signal);
         return parseAircraftList(resp.ac, parseOpts);
       },
     });

--- a/src/lib/flight-api-parsing.test.ts
+++ b/src/lib/flight-api-parsing.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseAircraftList } from "./flight-api-parsing";
+import type { RawAircraft } from "./flight-api-types";
+
+const LOOKUP_OPTIONS = {
+  includeGround: true,
+  requireBaroAltitude: false,
+};
+
+test("parses the API 2.0.0 aircraft shape with omitted optional fields", () => {
+  const flights = parseAircraftList(
+    [
+      {
+        hex: "ABC123",
+        lat: 12.5,
+        lon: 77.6,
+        seen_pos: 0.5,
+        dst: 10.2,
+        dir: 245,
+      },
+    ],
+    LOOKUP_OPTIONS,
+  );
+
+  assert.equal(flights.length, 1);
+  assert.equal(flights[0].icao24, "abc123");
+  assert.equal(flights[0].positionSource, null);
+  assert.equal(flights[0].debugData?.messages, null);
+});
+
+test("skips missing, non-ICAO, and malformed hex values without throwing", () => {
+  const malformed = [
+    { lat: 1, lon: 2 },
+    { hex: 123456, lat: 1, lon: 2 },
+    { hex: "~abc12", lat: 1, lon: 2 },
+    { hex: "nothex", lat: 1, lon: 2 },
+  ] as unknown as RawAircraft[];
+
+  assert.doesNotThrow(() => parseAircraftList(malformed, LOOKUP_OPTIONS));
+  assert.deepEqual(parseAircraftList(malformed, LOOKUP_OPTIONS), []);
+});
+
+test("rejects invalid positions and malformed position ages", () => {
+  const aircraft = [
+    { hex: "abc001", lat: 91, lon: 0 },
+    { hex: "abc002", lat: 0, lon: 181 },
+    { hex: "abc003", lat: Number.NaN, lon: 0 },
+    { hex: "abc004", lat: 0, lon: 0, seen_pos: 61 },
+    { hex: "abc005", lat: 0, lon: 0, seen_pos: -1 },
+    { hex: "abc006", lat: 0, lon: 0, seen_pos: "fresh" },
+  ] as unknown as RawAircraft[];
+
+  assert.deepEqual(parseAircraftList(aircraft, LOOKUP_OPTIONS), []);
+});
+
+test("never substitutes lastPosition for a missing live position", () => {
+  const flights = parseAircraftList(
+    [
+      {
+        hex: "abc123",
+        lastPosition: {
+          lat: 12.5,
+          lon: 77.6,
+          seen_pos: 120,
+        },
+      },
+    ],
+    LOOKUP_OPTIONS,
+  );
+
+  assert.deepEqual(flights, []);
+});
+
+test("malformed optional values are normalized instead of throwing", () => {
+  const flights = parseAircraftList(
+    [
+      {
+        hex: "abc123",
+        lat: 12.5,
+        lon: 77.6,
+        flight: 123,
+        r: false,
+        desc: {},
+        nav_modes: "autopilot",
+        messages: "many",
+      } as unknown as RawAircraft,
+    ],
+    LOOKUP_OPTIONS,
+  );
+
+  assert.equal(flights.length, 1);
+  assert.equal(flights[0].callsign, null);
+  assert.equal(flights[0].registration, null);
+  assert.equal(flights[0].navModes, null);
+  assert.equal(flights[0].debugData?.messages, null);
+});

--- a/src/lib/flight-api-parsing.ts
+++ b/src/lib/flight-api-parsing.ts
@@ -91,8 +91,8 @@ for (const [prefix, country] of REG_PREFIX_TO_COUNTRY) {
   else REG_BY_1.set(prefix, country);
 }
 
-function countryFromRegistration(reg: string | undefined): string {
-  if (!reg) return "Unknown";
+function countryFromRegistration(reg: unknown): string {
+  if (typeof reg !== "string" || !reg) return "Unknown";
   const upper = reg.toUpperCase();
   return (
     REG_BY_3.get(upper.slice(0, 3)) ??
@@ -108,8 +108,8 @@ function countryFromRegistration(reg: string | undefined): string {
 // used by OpenSky (DO-260B spec). A-set: A0→0, A1→2(light)…A7→8(rotorcraft).
 // B-set: B0→0, B1→9(glider)…B7→15(space). C-set: surface vehicles. D: reserved.
 
-function readsbCategoryToNumber(cat: string | undefined): number | null {
-  if (!cat || cat.length !== 2) return null;
+function readsbCategoryToNumber(cat: unknown): number | null {
+  if (typeof cat !== "string" || cat.length !== 2) return null;
 
   const set = cat.charAt(0).toUpperCase();
   const idx = Number.parseInt(cat.charAt(1), 10);
@@ -138,9 +138,9 @@ function readsbCategoryToNumber(cat: string | undefined): number | null {
  * tisb_icao, adsc, mode_s, and other provider-specific variants.
  */
 function readsbTypeToPositionSource(
-  type: string | undefined,
+  type: unknown,
 ): PositionSource {
-  if (!type) return null;
+  if (typeof type !== "string" || !type) return null;
   const normalized = type.toLowerCase();
 
   if (normalized.startsWith("adsb") || normalized.startsWith("adsr")) {
@@ -155,7 +155,7 @@ function readsbTypeToPositionSource(
 
 // ── Altitude Parser ────────────────────────────────────────────────────
 
-function parseAltBaro(value: number | "ground" | undefined): {
+function parseAltBaro(value: unknown): {
   altitude: number | null;
   onGround: boolean;
 } {
@@ -169,16 +169,22 @@ function parseAltBaro(value: number | "ground" | undefined): {
 
 const ICAO_HEX_RE = /^[0-9a-f]{6}$/i;
 
-function isValidIcaoHex(hex: string): boolean {
+function isValidIcaoHex(hex: unknown): hex is string {
   // Filter out '~'-prefixed non-ICAO addresses and invalid formats
-  return !hex.startsWith("~") && ICAO_HEX_RE.test(hex);
+  return (
+    typeof hex === "string" && !hex.startsWith("~") && ICAO_HEX_RE.test(hex)
+  );
 }
 
 // ── Optional Finite Helper ─────────────────────────────────────────────
 
 /** Returns the value if it's a finite number, otherwise null. */
-function optionalFinite(v: number | undefined): number | null {
+function optionalFinite(v: unknown): number | null {
   return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+function optionalTrimmedString(value: unknown): string | null {
+  return typeof value === "string" ? value.trim() || null : null;
 }
 
 // ── Single Aircraft Parser ─────────────────────────────────────────────
@@ -194,14 +200,21 @@ function parseRawAircraft(raw: RawAircraft): FlightState | null {
     return null;
 
   // Filter stale positions (>60s old)
-  if (typeof raw.seen_pos === "number" && raw.seen_pos > MAX_POSITION_AGE_S)
+  if (
+    raw.seen_pos !== undefined &&
+    (typeof raw.seen_pos !== "number" ||
+      !Number.isFinite(raw.seen_pos) ||
+      raw.seen_pos < 0 ||
+      raw.seen_pos > MAX_POSITION_AGE_S)
+  ) {
     return null;
+  }
 
   const { altitude, onGround } = parseAltBaro(raw.alt_baro);
 
   return {
     icao24: raw.hex.toLowerCase(),
-    callsign: raw.flight?.trim() || null,
+    callsign: optionalTrimmedString(raw.flight),
     originCountry: countryFromRegistration(raw.r),
     longitude: raw.lon,
     latitude: raw.lat,
@@ -227,12 +240,12 @@ function parseRawAircraft(raw: RawAircraft): FlightState | null {
       typeof raw.alt_geom === "number" && Number.isFinite(raw.alt_geom)
         ? raw.alt_geom * FT_TO_M
         : null,
-    squawk: raw.squawk ?? null,
+    squawk: optionalTrimmedString(raw.squawk),
     spiFlag: raw.spi === 1,
     positionSource: readsbTypeToPositionSource(raw.type),
     category: readsbCategoryToNumber(raw.category),
-    typeCode: raw.t?.trim() || null,
-    registration: raw.r?.trim() || null,
+    typeCode: optionalTrimmedString(raw.t),
+    registration: optionalTrimmedString(raw.r),
 
     // ── Avionics (readsb-only, will be undefined for OpenSky) ──────
     ias: optionalFinite(raw.ias),
@@ -247,7 +260,12 @@ function parseRawAircraft(raw: RawAircraft): FlightState | null {
     navAltitudeFms: optionalFinite(raw.nav_altitude_fms),
     navHeading: optionalFinite(raw.nav_heading),
     navQnh: optionalFinite(raw.nav_qnh),
-    navModes: raw.nav_modes && raw.nav_modes.length > 0 ? raw.nav_modes : null,
+    navModes:
+      Array.isArray(raw.nav_modes) &&
+      raw.nav_modes.every((mode) => typeof mode === "string") &&
+      raw.nav_modes.length > 0
+        ? raw.nav_modes
+        : null,
 
     // ── Atmospheric ────────────────────────────────────────────────
     windDirection: optionalFinite(raw.wd),
@@ -255,10 +273,12 @@ function parseRawAircraft(raw: RawAircraft): FlightState | null {
     oat: optionalFinite(raw.oat),
 
     // ── Classification ─────────────────────────────────────────────
-    dbFlags: typeof raw.dbFlags === "number" ? raw.dbFlags : null,
+    dbFlags: optionalFinite(raw.dbFlags),
     emergencyStatus:
-      raw.emergency && raw.emergency !== "none" ? raw.emergency : null,
-    typeDescription: raw.desc?.trim() || null,
+      typeof raw.emergency === "string" && raw.emergency !== "none"
+        ? raw.emergency
+        : null,
+    typeDescription: optionalTrimmedString(raw.desc),
 
     // ── Debug / Raw Data (readsb only) ───────────────────────────────
     debugData: {

--- a/src/lib/flight-api-parsing.ts
+++ b/src/lib/flight-api-parsing.ts
@@ -2,7 +2,7 @@
 //
 // Converts raw readsb JSON (RawAircraft[]) → FlightState[].
 // Handles unit conversions, edge cases, and stale-position filtering.
-// Works identically for Airplanes.live and adsb.lol responses.
+// Works identically for airplanes.live, adsb.lol, and adsb.fi responses.
 // ────────────────────────────────────────────────────────────────────────
 
 import type { FlightState, PositionSource } from "./opensky-types";

--- a/src/lib/flight-api-types.ts
+++ b/src/lib/flight-api-types.ts
@@ -1,6 +1,6 @@
 // ── readsb API Types ─────────────────────────────────────────────────
 //
-// Shared format used by both Airplanes.live and adsb.lol.
+// Shared format used by airplanes.live, adsb.lol, and adsb.fi.
 // Verified against official docs:
 //   https://api.airplanes.live/openapi.json
 //   https://api.adsb.lol/api/openapi.json
@@ -32,7 +32,7 @@ export const PROVIDER_ADSB_LOL: FlightApiProvider = {
 export const PROVIDER_ADSB_FI: FlightApiProvider = {
   name: "adsb.fi",
   baseUrl: "https://opendata.adsb.fi/api",
-  rateMs: 1_100, // Public API limit: 1 req/s
+  rateMs: 1_100, // Public API limit: 1 req/s per IP
 };
 
 export const PROVIDERS: readonly FlightApiProvider[] = [

--- a/src/lib/flight-api-types.ts
+++ b/src/lib/flight-api-types.ts
@@ -4,6 +4,7 @@
 // Verified against official docs:
 //   https://api.airplanes.live/openapi.json
 //   https://api.adsb.lol/api/openapi.json
+//   https://github.com/adsbfi/opendata
 //   https://github.com/wiedehopf/readsb/blob/dev/README-json.md
 // ────────────────────────────────────────────────────────────────────────
 
@@ -28,8 +29,15 @@ export const PROVIDER_ADSB_LOL: FlightApiProvider = {
   rateMs: 500, // Self-imposed: 2 req/s
 };
 
+export const PROVIDER_ADSB_FI: FlightApiProvider = {
+  name: "adsb.fi",
+  baseUrl: "https://opendata.adsb.fi/api",
+  rateMs: 1_100, // Public API limit: 1 req/s
+};
+
 export const PROVIDERS: readonly FlightApiProvider[] = [
   PROVIDER_ADSB_LOL,
+  PROVIDER_ADSB_FI,
   PROVIDER_AIRPLANES_LIVE,
 ] as const;
 

--- a/src/lib/flight-api-types.ts
+++ b/src/lib/flight-api-types.ts
@@ -2,7 +2,7 @@
 //
 // Shared format used by both Airplanes.live and adsb.lol.
 // Verified against official docs:
-//   https://airplanes.live/rest-api-adsb-data-field-descriptions/
+//   https://api.airplanes.live/openapi.json
 //   https://api.adsb.lol/api/openapi.json
 //   https://github.com/wiedehopf/readsb/blob/dev/README-json.md
 // ────────────────────────────────────────────────────────────────────────
@@ -19,7 +19,7 @@ export interface FlightApiProvider {
 export const PROVIDER_AIRPLANES_LIVE: FlightApiProvider = {
   name: "Airplanes.live",
   baseUrl: "https://api.airplanes.live/v2",
-  rateMs: 1_000, // Documented: 1 req/s
+  rateMs: 1_100, // Conservative best-effort floor; no published 2.0.0 quota
 };
 
 export const PROVIDER_ADSB_LOL: FlightApiProvider = {
@@ -29,8 +29,8 @@ export const PROVIDER_ADSB_LOL: FlightApiProvider = {
 };
 
 export const PROVIDERS: readonly FlightApiProvider[] = [
-  PROVIDER_AIRPLANES_LIVE,
   PROVIDER_ADSB_LOL,
+  PROVIDER_AIRPLANES_LIVE,
 ] as const;
 
 // ── API Constants ──────────────────────────────────────────────────────
@@ -52,13 +52,13 @@ export const NM_PER_DEG_LAT = 60;
 /**
  * A single aircraft entry from the readsb JSON response.
  * Keys are omitted by the API if data is not available.
- * @see https://airplanes.live/rest-api-adsb-data-field-descriptions/
+ * @see https://api.airplanes.live/openapi.json - Aircraft
  */
 export interface RawAircraft {
   /** 24-bit ICAO hex address (6 chars). Starts with '~' for non-ICAO. */
-  hex: string;
+  hex?: string;
   /** Type of underlying message source (adsb_icao, mlat, tisb_icao, etc.) */
-  type: string;
+  type?: string;
   /** Callsign, 8-char padded with trailing spaces. */
   flight?: string;
   /** Aircraft registration from database. */
@@ -74,6 +74,10 @@ export interface RawAircraft {
   lat?: number;
   lon?: number;
   seen_pos?: number;
+  /** Distance from the point query center, nautical miles. */
+  dst?: number;
+  /** Bearing from the point query center, degrees. */
+  dir?: number;
 
   // ── Altitude ───────────────────────────────────────────────────────
   /** In feet, or "ground" when on ground. */
@@ -139,20 +143,20 @@ export interface RawAircraft {
   version?: number;
 
   // ── Message stats ──────────────────────────────────────────────────
-  messages: number;
-  seen: number;
+  messages?: number;
+  seen?: number;
   /** dBFS (always negative). */
-  rssi: number;
-  mlat: string[];
-  tisb: string[];
+  rssi?: number;
+  mlat?: string[];
+  tisb?: string[];
 
   // ── Fallback position (stale) ──────────────────────────────────────
   lastPosition?: {
-    lat: number;
-    lon: number;
-    nic: number;
-    rc: number;
-    seen_pos: number;
+    lat?: number;
+    lon?: number;
+    nic?: number;
+    rc?: number;
+    seen_pos?: number;
   };
 
   // ── Rough estimated position ───────────────────────────────────────
@@ -169,6 +173,6 @@ export interface ReadsbApiResponse {
   msg: string;
   now: number;
   total: number;
-  ctime: number;
-  ptime: number;
+  ctime?: number;
+  ptime?: number;
 }

--- a/src/lib/flight-api.ts
+++ b/src/lib/flight-api.ts
@@ -1,16 +1,14 @@
 /**
  * Flight API client - barrel re-export.
  *
- * Default 2-tier fallback chain:
- *   Tier 1: adsb.lol       (via proxy, no CORS)
- *   Tier 2: OpenSky        (direct, CORS OK, limited credits)
- *
- * airplanes.live is available via explicit override only (CORS blocks
- * direct browser requests).
+ * Default 3-tier fallback chain:
+ *   Tier 1: adsb.lol       (server proxy)
+ *   Tier 2: airplanes.live (server proxy, best effort)
+ *   Tier 3: OpenSky        (direct, limited credits)
  *
  * Override: add ?provider=airplanes|adsb|opensky to the URL.
  *
- * @see https://airplanes.live/api-guide/
+ * @see https://api.airplanes.live/openapi.json
  * @see https://api.adsb.lol/docs
  * @see https://openskynetwork.github.io/opensky-api/rest.html
  */

--- a/src/lib/flight-api.ts
+++ b/src/lib/flight-api.ts
@@ -1,15 +1,17 @@
 /**
  * Flight API client - barrel re-export.
  *
- * Default 3-tier fallback chain:
+ * Default 4-tier fallback chain:
  *   Tier 1: adsb.lol       (server proxy)
- *   Tier 2: airplanes.live (server proxy, best effort)
- *   Tier 3: OpenSky        (direct, limited credits)
+ *   Tier 2: adsb.fi        (server proxy, public fallback)
+ *   Tier 3: airplanes.live (server proxy, best effort)
+ *   Tier 4: OpenSky        (direct, limited credits)
  *
- * Override: add ?provider=airplanes|adsb|opensky to the URL.
+ * Override: add ?provider=airplanes|adsb|adsbfi|opensky to the URL.
  *
  * @see https://api.airplanes.live/openapi.json
  * @see https://api.adsb.lol/docs
+ * @see https://github.com/adsbfi/opendata
  * @see https://openskynetwork.github.io/opensky-api/rest.html
  */
 
@@ -27,6 +29,8 @@ export {
   fetchFlightByHex,
   fetchFlightByCallsign,
   getProviderOverride,
+  setProviderOverride,
+  PROVIDER_CHANGE_EVENT,
   getCircuitState,
   resetAllCircuits,
 } from "./flight-api-client";

--- a/src/lib/search-flight-client.integration.test.ts
+++ b/src/lib/search-flight-client.integration.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { resetAllCircuits } from "./flight-api-client";
 
 async function importFresh() {
   const key = require.resolve("./search-flight-client");
@@ -7,33 +8,36 @@ async function importFresh() {
   return import("./search-flight-client");
 }
 
+function readsbBody(ac: unknown[]): string {
+  return JSON.stringify({ ac, msg: "No error", now: 1, total: ac.length });
+}
+
 test("searchFlightsGlobal finds AXB2680 when user searches IX2680", async () => {
+  resetAllCircuits();
   const calls: string[] = [];
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (input: RequestInfo | URL) => {
     const url = typeof input === "string" ? input : input.toString();
     calls.push(url);
     if (url.includes("hex")) {
-      return new Response(JSON.stringify({ ac: [] }), { status: 200 });
+      return new Response(readsbBody([]), { status: 200 });
     }
     if (url.includes("IX2680")) {
-      return new Response(JSON.stringify({ ac: [] }), { status: 200 });
+      return new Response(readsbBody([]), { status: 200 });
     }
     if (url.includes("AXB2680")) {
       return new Response(
-        JSON.stringify({
-          ac: [
-            {
-              hex: "801673",
-              flight: "AXB2680 ",
-              lat: 12.9,
-              lon: 80.1,
-              alt_baro: 32000,
-              gs: 430,
-              track: 85,
-            },
-          ],
-        }),
+        readsbBody([
+          {
+            hex: "801673",
+            flight: "AXB2680 ",
+            lat: 12.9,
+            lon: 80.1,
+            alt_baro: 32000,
+            gs: 430,
+            track: 85,
+          },
+        ]),
         { status: 200 },
       );
     }
@@ -54,33 +58,32 @@ test("searchFlightsGlobal finds AXB2680 when user searches IX2680", async () => 
 });
 
 test("searchFlightsGlobal finds AXB2680 when user searches AXB2680", async () => {
+  resetAllCircuits();
   const calls: string[] = [];
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (input: RequestInfo | URL) => {
     const url = typeof input === "string" ? input : input.toString();
     calls.push(url);
     if (url.includes("hex")) {
-      return new Response(JSON.stringify({ ac: [] }), { status: 200 });
+      return new Response(readsbBody([]), { status: 200 });
     }
     if (url.includes("AXB2680")) {
       return new Response(
-        JSON.stringify({
-          ac: [
-            {
-              hex: "801673",
-              flight: "AXB2680 ",
-              lat: 12.9,
-              lon: 80.1,
-              alt_baro: 32000,
-              gs: 430,
-              track: 85,
-            },
-          ],
-        }),
+        readsbBody([
+          {
+            hex: "801673",
+            flight: "AXB2680 ",
+            lat: 12.9,
+            lon: 80.1,
+            alt_baro: 32000,
+            gs: 430,
+            track: 85,
+          },
+        ]),
         { status: 200 },
       );
     }
-    return new Response(JSON.stringify({ ac: [] }), { status: 200 });
+    return new Response(readsbBody([]), { status: 200 });
   };
 
   try {
@@ -96,36 +99,35 @@ test("searchFlightsGlobal finds AXB2680 when user searches AXB2680", async () =>
 });
 
 test("searchFlightsGlobal finds AAL1234 when user searches AA1234", async () => {
+  resetAllCircuits();
   const calls: string[] = [];
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (input: RequestInfo | URL) => {
     const url = typeof input === "string" ? input : input.toString();
     calls.push(url);
     if (url.includes("hex")) {
-      return new Response(JSON.stringify({ ac: [] }), { status: 200 });
+      return new Response(readsbBody([]), { status: 200 });
     }
     if (url.includes("AA1234")) {
-      return new Response(JSON.stringify({ ac: [] }), { status: 200 });
+      return new Response(readsbBody([]), { status: 200 });
     }
     if (url.includes("AAL1234")) {
       return new Response(
-        JSON.stringify({
-          ac: [
-            {
-              hex: "aabbcc",
-              flight: "AAL1234 ",
-              lat: 33.9,
-              lon: -118.4,
-              alt_baro: 25000,
-              gs: 400,
-              track: 270,
-            },
-          ],
-        }),
+        readsbBody([
+          {
+            hex: "aabbcc",
+            flight: "AAL1234 ",
+            lat: 33.9,
+            lon: -118.4,
+            alt_baro: 25000,
+            gs: 400,
+            track: 270,
+          },
+        ]),
         { status: 200 },
       );
     }
-    return new Response(JSON.stringify({ ac: [] }), { status: 200 });
+    return new Response(readsbBody([]), { status: 200 });
   };
 
   try {

--- a/src/lib/search-flight-client.test.ts
+++ b/src/lib/search-flight-client.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { resetAllCircuits } from "./flight-api-client";
 
 // We must reset the module cache between tests because search-flight-client
 // holds module-level state (cache Map).
@@ -9,30 +10,33 @@ async function importFresh() {
   return import("./search-flight-client");
 }
 
+function readsbBody(ac: unknown[]): string {
+  return JSON.stringify({ ac, msg: "No error", now: 1, total: ac.length });
+}
+
 test("searchFlightsGlobal tries hex then callsign for 6-char hex-like query", async () => {
+  resetAllCircuits();
   const calls: string[] = [];
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (input: RequestInfo | URL) => {
     const url = typeof input === "string" ? input : input.toString();
     calls.push(url);
     if (url.includes("hex")) {
-      return new Response(JSON.stringify({ ac: [] }), { status: 200 });
+      return new Response(readsbBody([]), { status: 200 });
     }
     if (url.includes("callsign")) {
       return new Response(
-        JSON.stringify({
-          ac: [
-            {
-              hex: "a1b2c3",
-              flight: "AA1234 ",
-              lat: 40.7,
-              lon: -74.0,
-              alt_baro: 30000,
-              gs: 450,
-              track: 90,
-            },
-          ],
-        }),
+        readsbBody([
+          {
+            hex: "a1b2c3",
+            flight: "AA1234 ",
+            lat: 40.7,
+            lon: -74.0,
+            alt_baro: 30000,
+            gs: 450,
+            track: 90,
+          },
+        ]),
         { status: 200 },
       );
     }
@@ -45,40 +49,39 @@ test("searchFlightsGlobal tries hex then callsign for 6-char hex-like query", as
     const results = await searchFlightsGlobal("AA1234");
     assert.equal(results.length, 1);
     assert.equal(results[0].icao24, "a1b2c3");
-    assert.equal(calls.length, 2);
+    assert.equal(calls.length, 4);
     assert.ok(calls[0].includes("hex"));
-    assert.ok(calls[1].includes("callsign"));
+    assert.ok(calls[3].includes("callsign"));
   } finally {
     globalThis.fetch = originalFetch;
   }
 });
 
-test("searchFlightsGlobal tries callsign variants then hex for non-hex query", async () => {
+test("searchFlightsGlobal tries callsign variants for a non-hex query", async () => {
+  resetAllCircuits();
   const calls: string[] = [];
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (input: RequestInfo | URL) => {
     const url = typeof input === "string" ? input : input.toString();
     calls.push(url);
-    if (url.includes("callsign")) {
-      return new Response(JSON.stringify({ ac: [] }), { status: 200 });
-    }
-    if (url.includes("hex")) {
+    if (url.includes("AXB2680") && url.includes("provider=adsb")) {
       return new Response(
-        JSON.stringify({
-          ac: [
-            {
-              hex: "abc123",
-              flight: "IX2680 ",
-              lat: 51.5,
-              lon: -0.1,
-              alt_baro: 25000,
-              gs: 400,
-              track: 180,
-            },
-          ],
-        }),
+        readsbBody([
+          {
+            hex: "abc123",
+            flight: "AXB2680 ",
+            lat: 51.5,
+            lon: -0.1,
+            alt_baro: 25000,
+            gs: 400,
+            track: 180,
+          },
+        ]),
         { status: 200 },
       );
+    }
+    if (url.includes("callsign")) {
+      return new Response(readsbBody([]), { status: 200 });
     }
     return new Response("{}", { status: 404 });
   };
@@ -89,16 +92,18 @@ test("searchFlightsGlobal tries callsign variants then hex for non-hex query", a
     const results = await searchFlightsGlobal("IX2680");
     assert.equal(results.length, 1);
     assert.equal(results[0].icao24, "abc123");
-    // Should try callsign variants first (IX2680, AXB2680) then hex fallback
+    // Should try the user-entered callsign and its ICAO airline-code variant.
     assert.ok(calls.length >= 2);
     assert.ok(calls[0].includes("callsign"));
-    assert.ok(calls[calls.length - 1].includes("hex"));
+    assert.ok(calls.some((call) => call.includes("AXB2680")));
+    assert.ok(calls.every((call) => !call.includes("%2Fhex%2F")));
   } finally {
     globalThis.fetch = originalFetch;
   }
 });
 
 test("searchFlightsGlobal returns empty on total failure without throwing", async () => {
+  resetAllCircuits();
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async () => {
     return new Response(JSON.stringify({ error: "bad" }), { status: 502 });
@@ -115,24 +120,23 @@ test("searchFlightsGlobal returns empty on total failure without throwing", asyn
 });
 
 test("searchFlightsGlobal uses cache on repeat query", async () => {
+  resetAllCircuits();
   let callCount = 0;
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async () => {
     callCount++;
     return new Response(
-      JSON.stringify({
-        ac: [
-          {
-            hex: "deadbf",
-            flight: "DEADBF ",
-            lat: 0,
-            lon: 0,
-            alt_baro: 10000,
-            gs: 300,
-            track: 0,
-          },
-        ],
-      }),
+      readsbBody([
+        {
+          hex: "deadbf",
+          flight: "DEADBF ",
+          lat: 0,
+          lon: 0,
+          alt_baro: 10000,
+          gs: 300,
+          track: 0,
+        },
+      ]),
       { status: 200 },
     );
   };
@@ -147,6 +151,93 @@ test("searchFlightsGlobal uses cache on repeat query", async () => {
     const r2 = await searchFlightsGlobal("DEADBF");
     assert.equal(r2.length, 1);
     assert.equal(callCount, 1); // cache hit, no extra fetch
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("search cache is scoped to the effective provider override", async () => {
+  resetAllCircuits();
+  const originalFetch = globalThis.fetch;
+  const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const location = { search: "?provider=adsb" };
+  let callCount = 0;
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: { location, addEventListener: () => {} },
+  });
+  globalThis.fetch = async (input: RequestInfo | URL) => {
+    callCount++;
+    const provider = input.toString().includes("provider=airplanes")
+      ? "AIR"
+      : "ADSB";
+    return new Response(
+      readsbBody([
+        {
+          hex: "abcdef",
+          flight: provider,
+          lat: 1,
+          lon: 2,
+          alt_baro: 10_000,
+        },
+      ]),
+      { status: 200 },
+    );
+  };
+
+  try {
+    const { searchFlightsGlobal, clearFlightSearchCache } = await importFresh();
+    clearFlightSearchCache();
+    assert.equal((await searchFlightsGlobal("abcdef"))[0]?.callsign, "ADSB");
+    location.search = "?provider=airplanes";
+    assert.equal((await searchFlightsGlobal("abcdef"))[0]?.callsign, "AIR");
+    assert.equal(callCount, 2);
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalWindow) {
+      Object.defineProperty(globalThis, "window", originalWindow);
+    } else {
+      delete (globalThis as typeof globalThis & { window?: unknown }).window;
+    }
+  }
+});
+
+test("global search falls back from adsb.lol to airplanes.live", async () => {
+  resetAllCircuits();
+  const originalFetch = globalThis.fetch;
+  const calls: string[] = [];
+  globalThis.fetch = async (input: RequestInfo | URL) => {
+    const url = input.toString();
+    calls.push(url);
+    if (url.includes("provider=adsb")) {
+      return new Response(readsbBody([]), { status: 200 });
+    }
+    if (url.includes("provider=airplanes")) {
+      return new Response(
+        readsbBody([
+          {
+            hex: "abc123",
+            flight: "BAW123 ",
+            lat: 51.5,
+            lon: -0.1,
+            alt_baro: 25_000,
+          },
+        ]),
+        { status: 200 },
+      );
+    }
+    return new Response(null, { status: 502 });
+  };
+
+  try {
+    const { searchFlightsGlobal, clearFlightSearchCache } = await importFresh();
+    clearFlightSearchCache();
+    const results = await searchFlightsGlobal("BAW123");
+    assert.equal(results[0]?.icao24, "abc123");
+    assert.match(calls[0], /provider=adsb/);
+    assert.match(calls[1], /provider=airplanes/);
+    assert.equal(calls.length, 2);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/src/lib/search-flight-client.test.ts
+++ b/src/lib/search-flight-client.test.ts
@@ -246,8 +246,8 @@ test("global search falls back from adsb.lol to adsb.fi", async () => {
     clearFlightSearchCache();
     const results = await searchFlightsGlobal("BAW123");
     assert.equal(results[0]?.icao24, "abc123");
-    assert.match(calls[0], /provider=adsb/);
-    assert.match(calls[1], /provider=adsbfi/);
+    assert.equal(providerFromRequest(calls[0]), "adsb");
+    assert.equal(providerFromRequest(calls[1]), "adsbfi");
     assert.equal(calls.length, 2);
   } finally {
     globalThis.fetch = originalFetch;

--- a/src/lib/search-flight-client.test.ts
+++ b/src/lib/search-flight-client.test.ts
@@ -14,6 +14,12 @@ function readsbBody(ac: unknown[]): string {
   return JSON.stringify({ ac, msg: "No error", now: 1, total: ac.length });
 }
 
+function providerFromRequest(input: RequestInfo | URL | string): string | null {
+  return new URL(input.toString(), "http://localhost").searchParams.get(
+    "provider",
+  );
+}
+
 test("searchFlightsGlobal tries hex then callsign for 6-char hex-like query", async () => {
   resetAllCircuits();
   const calls: string[] = [];
@@ -49,9 +55,9 @@ test("searchFlightsGlobal tries hex then callsign for 6-char hex-like query", as
     const results = await searchFlightsGlobal("AA1234");
     assert.equal(results.length, 1);
     assert.equal(results[0].icao24, "a1b2c3");
-    assert.equal(calls.length, 4);
+    assert.equal(calls.length, 5);
     assert.ok(calls[0].includes("hex"));
-    assert.ok(calls[3].includes("callsign"));
+    assert.ok(calls[4].includes("callsign"));
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -64,7 +70,7 @@ test("searchFlightsGlobal tries callsign variants for a non-hex query", async ()
   globalThis.fetch = async (input: RequestInfo | URL) => {
     const url = typeof input === "string" ? input : input.toString();
     calls.push(url);
-    if (url.includes("AXB2680") && url.includes("provider=adsb")) {
+    if (url.includes("AXB2680") && providerFromRequest(url) === "adsb") {
       return new Response(
         readsbBody([
           {
@@ -169,9 +175,12 @@ test("search cache is scoped to the effective provider override", async () => {
   });
   globalThis.fetch = async (input: RequestInfo | URL) => {
     callCount++;
-    const provider = input.toString().includes("provider=airplanes")
-      ? "AIR"
-      : "ADSB";
+    const provider =
+      providerFromRequest(input) === "airplanes"
+        ? "AIR"
+        : providerFromRequest(input) === "adsbfi"
+          ? "FI"
+          : "ADSB";
     return new Response(
       readsbBody([
         {
@@ -190,9 +199,11 @@ test("search cache is scoped to the effective provider override", async () => {
     const { searchFlightsGlobal, clearFlightSearchCache } = await importFresh();
     clearFlightSearchCache();
     assert.equal((await searchFlightsGlobal("abcdef"))[0]?.callsign, "ADSB");
+    location.search = "?provider=adsbfi";
+    assert.equal((await searchFlightsGlobal("abcdef"))[0]?.callsign, "FI");
     location.search = "?provider=airplanes";
     assert.equal((await searchFlightsGlobal("abcdef"))[0]?.callsign, "AIR");
-    assert.equal(callCount, 2);
+    assert.equal(callCount, 3);
   } finally {
     globalThis.fetch = originalFetch;
     if (originalWindow) {
@@ -203,17 +214,17 @@ test("search cache is scoped to the effective provider override", async () => {
   }
 });
 
-test("global search falls back from adsb.lol to airplanes.live", async () => {
+test("global search falls back from adsb.lol to adsb.fi", async () => {
   resetAllCircuits();
   const originalFetch = globalThis.fetch;
   const calls: string[] = [];
   globalThis.fetch = async (input: RequestInfo | URL) => {
     const url = input.toString();
     calls.push(url);
-    if (url.includes("provider=adsb")) {
+    if (providerFromRequest(url) === "adsb") {
       return new Response(readsbBody([]), { status: 200 });
     }
-    if (url.includes("provider=airplanes")) {
+    if (providerFromRequest(url) === "adsbfi") {
       return new Response(
         readsbBody([
           {
@@ -236,7 +247,7 @@ test("global search falls back from adsb.lol to airplanes.live", async () => {
     const results = await searchFlightsGlobal("BAW123");
     assert.equal(results[0]?.icao24, "abc123");
     assert.match(calls[0], /provider=adsb/);
-    assert.match(calls[1], /provider=airplanes/);
+    assert.match(calls[1], /provider=adsbfi/);
     assert.equal(calls.length, 2);
   } finally {
     globalThis.fetch = originalFetch;

--- a/src/lib/search-flight-client.ts
+++ b/src/lib/search-flight-client.ts
@@ -1,7 +1,7 @@
 // ── Global Flight Search Client ────────────────────────────────────────
 //
 // Searches live aircraft globally by callsign or ICAO24 hex.
-// Uses the existing server proxy (/api/flights) with adsb.lol fallback chain.
+// Uses the shared provider chain and circuit state used by map/flight lookups.
 //
 // Verified endpoints (actual API docs):
 //   adsb.lol:     https://api.adsb.lol/v2/callsign/{callsign}
@@ -13,15 +13,15 @@
 // ────────────────────────────────────────────────────────────────────────
 
 import type { FlightState } from "./opensky-types";
-import type { ReadsbApiResponse } from "./flight-api-types";
-import { parseAircraftList, type ParseOptions } from "./flight-api-parsing";
+import {
+  fetchFlightsByCallsign,
+  fetchFlightsByHex,
+  getProviderOverride,
+  type ProviderName,
+} from "./flight-api-client";
 import { expandFlightQuery } from "./airlines";
 
 const SEARCH_TIMEOUT_MS = 10_000;
-const DEFAULT_PARSE_OPTS: ParseOptions = {
-  includeGround: true,
-  requireBaroAltitude: false,
-};
 
 // ── Client-Side Cache ──────────────────────────────────────────────────
 
@@ -35,12 +35,16 @@ const CACHE_TTL_MS = 8_000; // 8 seconds for hits - flights move fast
 const CACHE_EMPTY_TTL_MS = 2_000; // 2 seconds for misses - don't block long
 const CACHE_MAX_ENTRIES = 30;
 
-function cacheKey(query: string): string {
-  return query.trim().toUpperCase().replace(/\s+/g, "");
+function cacheKey(query: string, provider: ProviderName): string {
+  const normalized = query.trim().toUpperCase().replace(/\s+/g, "");
+  return `${provider}:${normalized}`;
 }
 
-function getCached(query: string): FlightState[] | undefined {
-  const key = cacheKey(query);
+function getCached(
+  query: string,
+  provider: ProviderName,
+): FlightState[] | undefined {
+  const key = cacheKey(query, provider);
   const entry = cache.get(key);
   if (!entry) return undefined;
   const ttl = entry.flights.length === 0 ? CACHE_EMPTY_TTL_MS : CACHE_TTL_MS;
@@ -51,8 +55,12 @@ function getCached(query: string): FlightState[] | undefined {
   return entry.flights;
 }
 
-function setCached(query: string, flights: FlightState[]): void {
-  const key = cacheKey(query);
+function setCached(
+  query: string,
+  provider: ProviderName,
+  flights: FlightState[],
+): void {
+  const key = cacheKey(query, provider);
   // Evict oldest if at capacity
   if (cache.size >= CACHE_MAX_ENTRIES && !cache.has(key)) {
     const oldest = cache.keys().next().value;
@@ -83,28 +91,19 @@ async function fetchFlightsByPath(
   signal?.addEventListener("abort", onAbort);
 
   try {
-    const res = await fetch(`/api/flights?path=${encodeURIComponent(path)}`, {
-      signal: controller.signal,
-      cache: "no-store",
-    });
-
-    if (!res.ok) {
-      if (res.status === 429) {
-        // Rate limited - return empty, let UI handle retry
-        return [];
-      }
-      return [];
+    const hexMatch = path.match(/^\/hex\/([0-9a-f]{6})$/i);
+    if (hexMatch) {
+      return (await fetchFlightsByHex(hexMatch[1], controller.signal)).flights;
     }
 
-    const data: unknown = await res.json();
-
-    // Validate readsb response shape
-    const response = data as ReadsbApiResponse;
-    if (!response || !Array.isArray(response.ac)) {
-      return [];
+    const callsignMatch = path.match(/^\/callsign\/([A-Z0-9-]{1,8})$/i);
+    if (callsignMatch) {
+      return (
+        await fetchFlightsByCallsign(callsignMatch[1], controller.signal)
+      ).flights;
     }
 
-    return parseAircraftList(response.ac, DEFAULT_PARSE_OPTS);
+    return [];
   } catch (err) {
     if (err instanceof DOMException && err.name === "AbortError") return [];
     return [];
@@ -120,9 +119,10 @@ export async function searchFlightsGlobal(
 ): Promise<FlightState[]> {
   const normalized = query.trim();
   if (!normalized) return [];
+  const provider = getProviderOverride();
 
   // Check cache first
-  const cached = getCached(normalized);
+  const cached = getCached(normalized, provider);
   if (cached) return cached;
 
   const compact = normalized.toLowerCase().replace(/\s+/g, "");
@@ -174,30 +174,23 @@ export async function searchFlightsGlobal(
     if (allFlights.length > 0) break;
   }
 
-  // ── Phase 2: Fallbacks for truly ambiguous 6-char queries ────────────
+  // ── Phase 2: Callsign fallback for truly ambiguous hex queries ──────
   //
   // If the original compact query is 6 hex chars and we still have no
   // results, try the opposite endpoint of what we already attempted.
   if (allFlights.length === 0 && !signal?.aborted) {
     const isHex = /^[0-9a-f]{6}$/i.test(compact);
     if (isHex) {
-      // Already tried hex above (if variant matched); try callsign as last resort
+      // Already tried hex above; the same six characters may be a callsign.
       const csResults = await fetchFlightsByPath(
         `/callsign/${compact.toUpperCase()}`,
         signal,
       );
       addUnique(csResults);
-    } else {
-      // Try hex fallback for non-hex queries
-      const hexResults = await fetchFlightsByPath(
-        `/hex/${compact.toLowerCase()}`,
-        signal,
-      );
-      addUnique(hexResults);
     }
   }
 
-  setCached(normalized, allFlights);
+  setCached(normalized, provider, allFlights);
   return allFlights;
 }
 

--- a/src/lib/search-flight-client.ts
+++ b/src/lib/search-flight-client.ts
@@ -6,6 +6,8 @@
 // Verified endpoints (actual API docs):
 //   adsb.lol:     https://api.adsb.lol/v2/callsign/{callsign}
 //                 https://api.adsb.lol/v2/hex/{icao_hex}
+//   adsb.fi:      https://opendata.adsb.fi/api/v2/callsign/{callsign}
+//                 https://opendata.adsb.fi/api/v2/hex/{hex}
 //   airplanes.live: https://api.airplanes.live/v2/callsign/{callsign}
 //                   https://api.airplanes.live/v2/hex/{hex}
 //


### PR DESCRIPTION
## Summary
Updates Aeris for the airplanes.live API 2.0.0 contract and adds adsb.fi between adsb.lol and airplanes.live in the automatic fallback order. Map polling, selected-flight lookup, FPV monitoring, and global search now share the same provider behavior. Provider changes also trigger an immediate refresh instead of waiting for the next polling cycle.

## Changes
- Hardened readsb parsing for optional fields, malformed aircraft, stale positions, `dst`, `dir`, and the API 2.0.0 response envelope.
- Added the adsb.fi v3 point endpoint and v2 hex and callsign endpoints through the existing server proxy.
- Added the adsb.lol, adsb.fi, airplanes.live, and OpenSky fallback order to point queries, lookups, FPV monitoring, and global search.
- Kept explicit provider selections pinned and isolated search caches by provider.
- Added conservative adsb.fi request pacing and retained strict path validation, geographic bounds, SSRF protection, timeouts, and identifying headers.
- Added immediate provider switching that cancels the previous request while preserving last-known aircraft until the selected source responds.
- Kept 401 and 403 responses on the immediate five-minute circuit cooldown while treating 429 as rate limiting.
- Added adsb.fi to the production picker, attribution, README, and the Aeris 0.8.8 changelog.
- Added proxy, client, fallback, search, and provider-selection regression coverage.

## Validation
- [x] `pnpm test` with 316 passing tests
- [x] `pnpm test:trails` with 153 passing tests
- [x] `pnpm lint` with 0 errors and 5 existing warnings
- [x] `pnpm build`
- [x] Chrome work profile smoke test for live adsb.fi data, provider order, immediate switching, attribution, explicit provider denial, automatic recovery, and last-known aircraft retention

## Production checklist
- [x] Branch is based on the current `origin/main` with zero divergence
- [x] Package version is `0.8.8`
- [x] In-app changelog and README match the four-provider production order
- [x] adsb.fi attribution links to its homepage
- [x] No database migration, API key, authentication header, or new environment variable is required
- [x] Upstream requests include the Aeris `0.8.8` identifying user agent
- [x] Latest GitHub checks pass

## Related
Issue/Task: airplanes.live API 2.0.0 compatibility and adsb.fi fallback

## Notes
The airplanes.live contract version is 2.0.0, but its production base URL remains `https://api.airplanes.live/v2`.

airplanes.live public requests may return 403 until provider access is approved. The integration reports the provider as unavailable and preserves last-known aircraft.

adsb.fi documents its public API for personal, non-commercial use at one request per second per IP and requires linked attribution. This integration applies conservative server-side pacing and includes the required link. Commercial use or higher request volume requires contacting adsb.fi.

The readsb providers do not return browser-compatible CORS headers, so live requests remain on the same-origin server proxy.
