### PR TITLE
Fuse selected aircraft data and validate routes

### DIFF
--- a/src/app/api/routes/route.test.ts
+++ b/src/app/api/routes/route.test.ts
@@ -30,7 +30,7 @@ test("GET rejects invalid callsigns without touching upstream providers", async 
 
     assert.equal(response.status, 400);
     assert.equal(response.headers.get("Cache-Control"), "no-store");
-    assert.equal(body.error, "Invalid or missing callsign");
+    assert.equal(body.error, "Invalid or missing route context");
     assert.equal(upstreamTouched, false);
   } finally {
     globalThis.fetch = originalFetch;
@@ -75,13 +75,16 @@ test("GET returns normalized route data with shared-cache headers", async () => 
   try {
     const routeModule = await import("./route");
     const request = new NextRequest(
-      "https://aeris.edbn.me/api/routes?callsign=aal789",
+      "https://aeris.edbn.me/api/routes?callsign=aal789&icao24=abc123&latitude=37.7&longitude=-122.4&altitudeMeters=10000&onGround=0&observationTime=1700000000000",
     );
 
     const response = await routeModule.GET(request);
     const route = (await response.json()) as {
       callsign?: string;
       source?: string;
+      sources?: string[];
+      validation?: string;
+      icao24?: string;
       origin?: { iata?: string };
       destination?: { iata?: string };
     };
@@ -89,10 +92,13 @@ test("GET returns normalized route data with shared-cache headers", async () => 
     assert.equal(response.status, 200);
     assert.equal(
       response.headers.get("Cache-Control"),
-      "public, max-age=300, s-maxage=900, stale-while-revalidate=1800",
+      "public, max-age=300, s-maxage=300, stale-while-revalidate=300",
     );
     assert.equal(route.callsign, "AAL789");
     assert.equal(route.source, "adsbdb");
+    assert.deepEqual(route.sources, ["adsbdb"]);
+    assert.equal(route.validation, "valid");
+    assert.equal(route.icao24, "abc123");
     assert.equal(route.origin?.iata, "SFO");
     assert.equal(route.destination?.iata, "LHR");
   } finally {
@@ -109,7 +115,7 @@ test("GET does not cache transient provider failures as route misses", async () 
   try {
     const routeModule = await import("./route");
     const request = new NextRequest(
-      "https://aeris.edbn.me/api/routes?callsign=ual790",
+      "https://aeris.edbn.me/api/routes?callsign=ual790&icao24=abc123&latitude=37.7&longitude=-122.4&altitudeMeters=10000&onGround=0&observationTime=1700000000000",
     );
 
     const response = await routeModule.GET(request);

--- a/src/app/api/routes/route.ts
+++ b/src/app/api/routes/route.ts
@@ -3,25 +3,49 @@ import {
   normalizeRouteCallsign,
   resolveRouteFromOpenDatabasesDetailed,
 } from "@/lib/route-resolver";
+import { normalizeRouteRequest } from "@/lib/route-lookup";
 
 const ROUTE_HIT_CACHE_CONTROL =
-  "public, max-age=300, s-maxage=900, stale-while-revalidate=1800";
-const ROUTE_MISS_CACHE_CONTROL = "public, max-age=60, s-maxage=120";
+  "public, max-age=300, s-maxage=300, stale-while-revalidate=300";
+const ROUTE_MISS_CACHE_CONTROL = "public, max-age=60, s-maxage=60";
 const SOURCES = ["adsbdb", "hexdb", "opensky"];
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const callsign = normalizeRouteCallsign(
     request.nextUrl.searchParams.get("callsign"),
   );
+  const latitudeValue = request.nextUrl.searchParams.get("latitude");
+  const longitudeValue = request.nextUrl.searchParams.get("longitude");
+  const latitude = latitudeValue === null ? Number.NaN : Number(latitudeValue);
+  const longitude =
+    longitudeValue === null ? Number.NaN : Number(longitudeValue);
+  const altitudeValue = request.nextUrl.searchParams.get("altitudeMeters");
+  const altitudeMeters = altitudeValue ? Number(altitudeValue) : null;
+  const observationTimeValue =
+    request.nextUrl.searchParams.get("observationTime");
+  const observationTime =
+    observationTimeValue === null ? Number.NaN : Number(observationTimeValue);
+  const onGroundValue = request.nextUrl.searchParams.get("onGround");
+  const context = callsign
+    ? normalizeRouteRequest({
+        callsign,
+        icao24: request.nextUrl.searchParams.get("icao24") ?? "",
+        latitude,
+        longitude,
+        altitudeMeters,
+        onGround: onGroundValue === "1",
+        observationTime,
+      })
+    : null;
 
-  if (!callsign) {
+  if (!context || (onGroundValue !== "0" && onGroundValue !== "1")) {
     return NextResponse.json(
-      { error: "Invalid or missing callsign" },
+      { error: "Invalid or missing route context" },
       { status: 400, headers: { "Cache-Control": "no-store" } },
     );
   }
 
-  const resolution = await resolveRouteFromOpenDatabasesDetailed(callsign);
+  const resolution = await resolveRouteFromOpenDatabasesDetailed(context);
   const route = resolution.route;
 
   if (!route) {
@@ -29,7 +53,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       return NextResponse.json(
         {
           error: "Route lookup temporarily unavailable",
-          callsign,
+          callsign: context.callsign,
           sources: SOURCES,
         },
         { status: 503, headers: { "Cache-Control": "no-store" } },
@@ -39,7 +63,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json(
       {
         error: "Route unavailable",
-        callsign,
+        callsign: context.callsign,
         sources: SOURCES,
       },
       {

--- a/src/components/flight-tracker-random.ts
+++ b/src/components/flight-tracker-random.ts
@@ -64,7 +64,7 @@ export function cityFromFlight(flight: FlightState): City | null {
   return {
     id: `trk-${flight.icao24}`,
     name: `Flight ${code}`,
-    country: flight.originCountry || "Unknown",
+    country: flight.registrationCountry || "Unknown",
     iata: code,
     coordinates: [flight.longitude, flight.latitude],
     radius: 2,

--- a/src/components/flight-tracker.tsx
+++ b/src/components/flight-tracker.tsx
@@ -45,6 +45,7 @@ import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { useFlights } from "@/hooks/use-flights";
 import { useTrailSystem } from "@/hooks/use-trail-system";
 import { useFlightMonitors } from "@/hooks/use-flight-monitors";
+import { useSelectedAircraft } from "@/hooks/use-selected-aircraft";
 import { useAtcStream } from "@/hooks/use-atc-stream";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useAirportBoard } from "@/hooks/use-airport-board";
@@ -255,10 +256,11 @@ function FlightTrackerInner({
     return m;
   }, [displayFlights]);
 
-  const selectedFlight = useMemo(() => {
+  const selectedMapFlight = useMemo(() => {
     if (!selectedIcao24) return null;
     return displayFlightMap.get(selectedIcao24) ?? null;
   }, [selectedIcao24, displayFlightMap]);
+  const selectedFlight = useSelectedAircraft(selectedMapFlight);
 
   const selectedTrail = useMemo(() => {
     if (!selectedIcao24) return null;

--- a/src/components/ui/control-panel-search.tsx
+++ b/src/components/ui/control-panel-search.tsx
@@ -364,7 +364,7 @@ export function SearchContent({
       <Command.Item
         key={flight.icao24}
         value={`flight:${flight.icao24}:${cs}:${isGlobal ? "global" : "local"}`}
-        keywords={[flight.icao24, cs, flight.originCountry]}
+        keywords={[flight.icao24, cs, flight.registrationCountry ?? ""]}
         onSelect={() => void openFlight(flight.icao24)}
         className="search-item"
       >
@@ -418,11 +418,11 @@ export function SearchContent({
             )}
             <span className="text-foreground/25">·</span>
             <CountryFlag
-              country={flight.originCountry}
+              country={flight.registrationCountry ?? "Unknown"}
               size={11}
               className="rounded-[1px]"
             />
-            <span className="truncate">{flight.originCountry}</span>
+            <span className="truncate">{flight.registrationCountry}</span>
           </div>
         </div>
 

--- a/src/components/ui/flight-card.tsx
+++ b/src/components/ui/flight-card.tsx
@@ -81,7 +81,10 @@ export function FlightCard({
   const airline = flight ? lookupAirline(flight.callsign) : null;
   const flightNum = flight ? parseFlightNumber(flight.callsign) : null;
   const company =
-    airline ?? (flight ? `${flight.originCountry} operator` : null);
+    airline ??
+    (flight?.registrationCountry
+      ? `${flight.registrationCountry} operator`
+      : null);
   const model = flight ? aircraftTypeHint(flight.category) : null;
   const logoCandidates = airlineLogoCandidates(airline, flight?.callsign);
   const heading = flight?.trueTrack ?? null;
@@ -384,7 +387,7 @@ export function FlightCard({
               <div className="mt-4 overflow-hidden rounded-[22px] border border-foreground/[0.07] bg-foreground/[0.035] shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]">
                 <GroupedRow icon={<Globe className="h-3.5 w-3.5" />}>
                   <p className="text-[13px] text-foreground/65">
-                    {flight.originCountry}
+                    {flight.registrationCountry}
                   </p>
                 </GroupedRow>
                 {cardinal && (

--- a/src/components/ui/fpv-hud.tsx
+++ b/src/components/ui/fpv-hud.tsx
@@ -369,7 +369,7 @@ export function FpvHud({ flight, onExit }: FpvHudProps) {
                 ) : null}
               </div>
               <p className="truncate text-[9px] font-medium uppercase tracking-widest text-foreground/30">
-                {airline ?? flight.originCountry}
+                {airline ?? flight.registrationCountry}
               </p>
             </div>
           </div>

--- a/src/components/ui/mobile-flight-toast.tsx
+++ b/src/components/ui/mobile-flight-toast.tsx
@@ -230,7 +230,11 @@ export function MobileFlightToast({
   const { settings } = useSettings();
   const airline = lookupAirline(flight.callsign);
   const flightNum = parseFlightNumber(flight.callsign);
-  const company = airline ?? `${flight.originCountry} operator`;
+  const company =
+    airline ??
+    (flight.registrationCountry
+      ? `${flight.registrationCountry} operator`
+      : null);
   const model = aircraftTypeHint(flight.category);
   const heading = flight.trueTrack;
   const cardinal = heading !== null ? headingToCardinal(heading) : null;
@@ -490,7 +494,7 @@ export function MobileFlightToast({
         {/* Origin country */}
         <MobileGroupedRow icon={<Globe className="h-3.5 w-3.5" />}>
           <p className="text-[13px] text-foreground/65">
-            {flight.originCountry}
+            {flight.registrationCountry}
           </p>
         </MobileGroupedRow>
 

--- a/src/hooks/use-route-info.test.ts
+++ b/src/hooks/use-route-info.test.ts
@@ -33,12 +33,16 @@ test("route-lookup module exports lookupRoute", async () => {
   assert.equal(typeof lookupRoute, "function");
 });
 
-test("route lookup parses full verified route from API", async () => {
+test("route lookup parses a complete reported route from API", async () => {
   const apiRoute: RouteInfo = {
     callsign: "UAL123",
+    icao24: "abc123",
     origin: sfo,
     destination: lhr,
     source: "adsbdb",
+    sources: ["adsbdb"],
+    validation: "valid",
+    validatedAt: Date.now(),
     fetchedAt: Date.now(),
   };
 
@@ -50,9 +54,13 @@ test("route lookup parses full verified route from API", async () => {
 test("route lookup accepts opensky source", async () => {
   const apiRoute: RouteInfo = {
     callsign: "BAW123",
+    icao24: "abc123",
     origin: lhr,
     destination: sfo,
     source: "opensky",
+    sources: ["opensky"],
+    validation: "valid",
+    validatedAt: Date.now(),
     fetchedAt: Date.now(),
   };
 

--- a/src/hooks/use-route-info.ts
+++ b/src/hooks/use-route-info.ts
@@ -2,16 +2,15 @@
 
 // ── Route Info Hook ─────────────────────────────────────────────────
 //
-// Fetches verified route data from external databases ONLY.
+// Fetches reported route data from external databases.
 //
 // Sources (queried in parallel server-side):
-//   1. adsbdb.com       – flight-plan database
-//   2. hexdb.io         – route lookup + airport metadata
-//   3. OpenSky Network  – historical route data
+//   1. adsbdb.com       flight-plan database
+//   2. hexdb.io         route lookup and airport metadata
+//   3. OpenSky Network  historical route data
 //
-// IMPORTANT: No predicted, observed, or interpolated routes are ever
-// shown. If none of the databases know the route, the UI displays
-// "Route unavailable" rather than guessing.
+// The server checks the reported route against the aircraft position.
+// It hides a route when the geometry conflicts.
 //
 // Edge cases handled:
 //   - Rapid flight switching: old requests are cancelled, only the
@@ -22,21 +21,26 @@
 //   - Cached results: instant display for recently-looked-up routes.
 // ────────────────────────────────────────────────────────────────────────
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import type { FlightState } from "@/lib/opensky";
-import { lookupRoute, formatAirportCode } from "@/lib/route-lookup";
+import {
+  lookupRoute,
+  formatAirportCode,
+  routeCacheKey,
+  type RouteSource,
+} from "@/lib/route-lookup";
 import type { RouteInfo, RouteAirport } from "@/lib/route-lookup";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
 export type FlightRouteInfo = {
-  /** Origin airport (verified from route database, or null) */
+  /** Origin airport from a reported route, or null */
   origin: RouteAirport | null;
-  /** Destination airport (verified from route database, or null) */
+  /** Destination airport from a reported route, or null */
   destination: RouteAirport | null;
   /** Whether route data is actively being fetched */
   loading: boolean;
-  /** Whether a verified route was found */
+  /** Whether a position-consistent reported route was found */
   available: boolean;
   /** Whether the route is definitively unknown (not just loading) */
   unavailable: boolean;
@@ -44,6 +48,10 @@ export type FlightRouteInfo = {
   routeDisplay: string | null;
   /** Data source that resolved this route */
   source: "adsbdb" | "hexdb" | "opensky" | null;
+  /** All route sources that returned the same endpoints */
+  sources: RouteSource[];
+  /** Time of the latest route validation */
+  validatedAt: number | null;
 };
 
 const EMPTY_ROUTE: FlightRouteInfo = {
@@ -54,6 +62,8 @@ const EMPTY_ROUTE: FlightRouteInfo = {
   unavailable: false,
   routeDisplay: null,
   source: null,
+  sources: [],
+  validatedAt: null,
 };
 
 /** Max time to wait for a route lookup before forcing timeout. */
@@ -71,6 +81,32 @@ export function useRouteInfo(flight: FlightState | null): FlightRouteInfo {
   const mountedRef = useRef(true);
 
   const callsign = flight?.callsign?.trim().toUpperCase() ?? null;
+  const routeRequest = useMemo(
+    () =>
+      flight &&
+      callsign &&
+      flight.latitude !== null &&
+      flight.longitude !== null
+        ? {
+            callsign,
+            icao24: flight.icao24,
+            latitude: flight.latitude,
+            longitude: flight.longitude,
+            altitudeMeters: flight.baroAltitude,
+            onGround: flight.onGround,
+            observationTime:
+              flight.provenance.observationTime ??
+              flight.provenance.responseTime,
+          }
+        : null,
+    [callsign, flight],
+  );
+  const requestKey = routeRequest ? routeCacheKey(routeRequest) : null;
+  const routeRequestRef = useRef(routeRequest);
+
+  useEffect(() => {
+    routeRequestRef.current = routeRequest;
+  }, [routeRequest]);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -80,8 +116,8 @@ export function useRouteInfo(flight: FlightState | null): FlightRouteInfo {
   }, []);
 
   useEffect(() => {
-    // No callsign → nothing to look up
-    if (!callsign) {
+    const activeRequest = routeRequestRef.current;
+    if (!activeRequest || !requestKey) {
       const generation = ++generationRef.current;
       queueMicrotask(() => {
         if (!mountedRef.current) return;
@@ -113,7 +149,7 @@ export function useRouteInfo(flight: FlightState | null): FlightRouteInfo {
       controller.abort();
     }, LOOKUP_TIMEOUT_MS);
 
-    lookupRoute(callsign, controller.signal)
+    lookupRoute(activeRequest, controller.signal)
       .then((result) => {
         settled = true;
         clearTimeout(timeoutId);
@@ -140,7 +176,7 @@ export function useRouteInfo(flight: FlightState | null): FlightRouteInfo {
       clearTimeout(timeoutId);
       controller.abort();
     };
-  }, [callsign]);
+  }, [requestKey]);
 
   if (!flight) return EMPTY_ROUTE;
 
@@ -161,6 +197,8 @@ export function useRouteInfo(flight: FlightState | null): FlightRouteInfo {
     unavailable: isUnavailable,
     routeDisplay,
     source: apiRoute?.source ?? null,
+    sources: apiRoute?.sources ?? [],
+    validatedAt: apiRoute?.validatedAt ?? null,
   };
 }
 

--- a/src/hooks/use-selected-aircraft.ts
+++ b/src/hooks/use-selected-aircraft.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import type { FlightState } from "@/lib/opensky";
+import {
+  fuseSelectedAircraft,
+  loadSelectedAircraftSources,
+  type SelectedAircraftSources,
+} from "@/lib/selected-aircraft";
+
+export function useSelectedAircraft(
+  current: FlightState | null,
+): FlightState | null {
+  const [sources, setSources] = useState<SelectedAircraftSources | null>(null);
+  const icao24 = current?.icao24 ?? null;
+
+  useEffect(() => {
+    if (!icao24) return;
+    const controller = new AbortController();
+    void loadSelectedAircraftSources(icao24, controller.signal)
+      .then((result) => {
+        if (!controller.signal.aborted) setSources(result);
+      })
+      .catch((error) => {
+        if (error instanceof Error && error.name === "AbortError") return;
+      });
+    return () => controller.abort();
+  }, [icao24]);
+
+  return useMemo(() => {
+    if (!current || sources?.icao24 !== current.icao24) return current;
+    return fuseSelectedAircraft(current, sources.fresh, sources.registry).flight;
+  }, [current, sources]);
+}

--- a/src/hooks/use-trail-history.test.ts
+++ b/src/hooks/use-trail-history.test.ts
@@ -12,7 +12,7 @@ import { useTrailHistory } from "./use-trail-history";
 const TEST_FLIGHT: FlightState = {
   icao24: "abc123",
   callsign: "TEST123",
-  originCountry: "Testland",
+  registrationCountry: "Testland",
   longitude: 8.55,
   latitude: 50.04,
   baroAltitude: 11_000,
@@ -25,6 +25,13 @@ const TEST_FLIGHT: FlightState = {
   spiFlag: false,
   positionSource: "adsb",
   category: null,
+  provenance: {
+    responseTime: 10_000,
+    observationTime: 9_500,
+    positionAgeSeconds: 0.5,
+    contributingSources: ["adsb.lol"],
+    positionProvider: "adsb.lol",
+  },
 };
 
 function HookHarness(props: { flights?: FlightState[] }) {

--- a/src/lib/country-codes.ts
+++ b/src/lib/country-codes.ts
@@ -1,7 +1,7 @@
 /**
  * Comprehensive country name → ISO 3166-1 alpha-2 mapping.
  *
- * Covers all ICAO / OpenSky originCountry values, common aliases,
+ * Covers all ICAO / OpenSky registrationCountry values, common aliases,
  * and historical names. Optimised for lookup speed (single pass,
  * normalised keys, early return).
  */

--- a/src/lib/flight-api-client.test.ts
+++ b/src/lib/flight-api-client.test.ts
@@ -6,6 +6,7 @@ import {
   fetchFlightsByCallsign,
   fetchFlightsByHex,
   fetchFlightsByPoint,
+  fetchSelectedAircraftFromAdsbLol,
   getCircuitState,
   PROVIDER_CHANGE_EVENT,
   resetAllCircuits,
@@ -220,6 +221,26 @@ test("an adsb.fi lookup miss continues to airplanes.live", async () => {
     assert.equal(providerFromRequest(calls[0]), "adsb");
     assert.equal(providerFromRequest(calls[1]), "adsbfi");
     assert.equal(providerFromRequest(calls[2]), "airplanes");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("selected-aircraft lookup calls only adsb.lol", async () => {
+  resetAllCircuits();
+  const calls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: RequestInfo | URL) => {
+    calls.push(input.toString());
+    return readsbResponse([rawAircraft()]);
+  };
+
+  try {
+    const flight = await fetchSelectedAircraftFromAdsbLol("abc123");
+    assert.equal(flight?.icao24, "abc123");
+    assert.equal(flight?.provenance.positionProvider, "adsb.lol");
+    assert.equal(calls.length, 1);
+    assert.equal(providerFromRequest(calls[0]), "adsb");
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/src/lib/flight-api-client.ts
+++ b/src/lib/flight-api-client.ts
@@ -208,6 +208,11 @@ export function setProviderOverride(provider: ProviderName): void {
 // ── Constants ──────────────────────────────────────────────────────────
 
 const PROXY_TIMEOUT_MS = 8_000;
+const PROVIDER_LABELS = {
+  adsb: "adsb.lol",
+  adsbfi: "adsb.fi",
+  airplanes: "airplanes.live",
+} as const;
 
 // ── Internal Helpers ───────────────────────────────────────────────────
 
@@ -296,6 +301,18 @@ async function fetchViaProxy(
     PROXY_TIMEOUT_MS,
     signal,
   );
+}
+
+function parseReadsbResponse(
+  response: ReadsbApiResponse,
+  provider: keyof typeof PROVIDER_LABELS,
+  options?: ParseOptions,
+): FlightState[] {
+  return parseAircraftList(response.ac, {
+    ...options,
+    positionProvider: PROVIDER_LABELS[provider],
+    responseTime: response.now,
+  });
 }
 
 // ── Tier 4: OpenSky direct ─────────────────────────────────────────────
@@ -422,7 +439,7 @@ export async function fetchFlightsByPoint(
       id: "adsb",
       fn: async () => {
         const resp = await fetchViaProxy(readsbPath, "adsb", signal);
-        return parseAircraftList(resp.ac, options);
+        return parseReadsbResponse(resp, "adsb", options);
       },
     });
   }
@@ -433,7 +450,7 @@ export async function fetchFlightsByPoint(
       id: "adsbfi",
       fn: async () => {
         const resp = await fetchViaProxy(readsbPath, "adsbfi", signal);
-        return parseAircraftList(resp.ac, options);
+        return parseReadsbResponse(resp, "adsbfi", options);
       },
     });
   }
@@ -444,7 +461,7 @@ export async function fetchFlightsByPoint(
       id: "airplanes",
       fn: async () => {
         const resp = await fetchViaProxy(readsbPath, "airplanes", signal);
-        return parseAircraftList(resp.ac, options);
+        return parseReadsbResponse(resp, "airplanes", options);
       },
     });
   }
@@ -494,7 +511,7 @@ export async function fetchFlightsByHex(
       id: "adsb",
       fn: async () => {
         const resp = await fetchViaProxy(readsbPath, "adsb", signal);
-        return parseAircraftList(resp.ac, parseOpts);
+        return parseReadsbResponse(resp, "adsb", parseOpts);
       },
     });
   }
@@ -505,7 +522,7 @@ export async function fetchFlightsByHex(
       id: "adsbfi",
       fn: async () => {
         const resp = await fetchViaProxy(readsbPath, "adsbfi", signal);
-        return parseAircraftList(resp.ac, parseOpts);
+        return parseReadsbResponse(resp, "adsbfi", parseOpts);
       },
     });
   }
@@ -516,7 +533,7 @@ export async function fetchFlightsByHex(
       id: "airplanes",
       fn: async () => {
         const resp = await fetchViaProxy(readsbPath, "airplanes", signal);
-        return parseAircraftList(resp.ac, parseOpts);
+        return parseReadsbResponse(resp, "airplanes", parseOpts);
       },
     });
   }
@@ -549,6 +566,32 @@ export async function fetchFlightsByHex(
   }
 }
 
+/** Fetch one fresh adsb.lol result for selected-aircraft fusion. */
+export async function fetchSelectedAircraftFromAdsbLol(
+  icao24: string,
+  signal?: AbortSignal,
+): Promise<FlightState | null> {
+  const normalized = icao24.trim().toLowerCase();
+  if (!/^[0-9a-f]{6}$/.test(normalized)) return null;
+
+  try {
+    const response = await fetchViaProxy(
+      `/hex/${encodeURIComponent(normalized)}`,
+      "adsb",
+      signal,
+    );
+    return (
+      parseReadsbResponse(response, "adsb", {
+        includeGround: true,
+        requireBaroAltitude: false,
+      }).find((flight) => flight.icao24 === normalized) ?? null
+    );
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") throw error;
+    return null;
+  }
+}
+
 /**
  * Fetch all aircraft matching a callsign.
  * Uses OpenSky only after all readsb providers miss or fail.
@@ -576,7 +619,7 @@ export async function fetchFlightsByCallsign(
       id: "adsb",
       fn: async () => {
         const resp = await fetchViaProxy(readsbPath, "adsb", signal);
-        return parseAircraftList(resp.ac, parseOpts);
+        return parseReadsbResponse(resp, "adsb", parseOpts);
       },
     });
   }
@@ -587,7 +630,7 @@ export async function fetchFlightsByCallsign(
       id: "adsbfi",
       fn: async () => {
         const resp = await fetchViaProxy(readsbPath, "adsbfi", signal);
-        return parseAircraftList(resp.ac, parseOpts);
+        return parseReadsbResponse(resp, "adsbfi", parseOpts);
       },
     });
   }
@@ -598,7 +641,7 @@ export async function fetchFlightsByCallsign(
       id: "airplanes",
       fn: async () => {
         const resp = await fetchViaProxy(readsbPath, "airplanes", signal);
-        return parseAircraftList(resp.ac, parseOpts);
+        return parseReadsbResponse(resp, "airplanes", parseOpts);
       },
     });
   }

--- a/src/lib/flight-api-parsing.test.ts
+++ b/src/lib/flight-api-parsing.test.ts
@@ -30,6 +30,32 @@ test("parses the API 2.0.0 aircraft shape with omitted optional fields", () => {
   assert.equal(flights[0].debugData?.messages, null);
 });
 
+test("preserves response time, position age, and provider identity", () => {
+  const flights = parseAircraftList(
+    [
+      {
+        hex: "ABC123",
+        lat: 12.5,
+        lon: 77.6,
+        seen_pos: 1.25,
+      },
+    ],
+    {
+      ...LOOKUP_OPTIONS,
+      positionProvider: "adsb.lol",
+      responseTime: 1_700_000_000_000,
+    },
+  );
+
+  assert.deepEqual(flights[0].provenance, {
+    responseTime: 1_700_000_000_000,
+    observationTime: 1_699_999_998_750,
+    positionAgeSeconds: 1.25,
+    contributingSources: ["adsb.lol"],
+    positionProvider: "adsb.lol",
+  });
+});
+
 test("skips missing, non-ICAO, and malformed hex values without throwing", () => {
   const malformed = [
     { lat: 1, lon: 2 },

--- a/src/lib/flight-api-parsing.ts
+++ b/src/lib/flight-api-parsing.ts
@@ -8,6 +8,10 @@
 import type { FlightState, PositionSource } from "./opensky-types";
 import type { RawAircraft } from "./flight-api-types";
 import { MAX_POSITION_AGE_S } from "./flight-api-types";
+import {
+  createFlightProvenance,
+  normalizeFlightTimestamp,
+} from "./flight-provenance";
 
 // ── Unit Conversion Constants ──────────────────────────────────────────
 
@@ -22,7 +26,7 @@ const FTPM_TO_MS = 0.00508;
 
 // ── Registration → Country Lookup ──────────────────────────────────────
 //
-// readsb doesn't provide originCountry. We derive it from the
+// readsb does not provide registrationCountry. We derive it from the
 // registration prefix. Sorted by prefix length descending so longer
 // prefixes match first (e.g. "EC-" before "E").
 
@@ -91,14 +95,14 @@ for (const [prefix, country] of REG_PREFIX_TO_COUNTRY) {
   else REG_BY_1.set(prefix, country);
 }
 
-function countryFromRegistration(reg: unknown): string {
-  if (typeof reg !== "string" || !reg) return "Unknown";
+function countryFromRegistration(reg: unknown): string | null {
+  if (typeof reg !== "string" || !reg) return null;
   const upper = reg.toUpperCase();
   return (
     REG_BY_3.get(upper.slice(0, 3)) ??
     REG_BY_2.get(upper.slice(0, 2)) ??
     REG_BY_1.get(upper[0]) ??
-    "Unknown"
+    null
   );
 }
 
@@ -189,7 +193,10 @@ function optionalTrimmedString(value: unknown): string | null {
 
 // ── Single Aircraft Parser ─────────────────────────────────────────────
 
-function parseRawAircraft(raw: RawAircraft): FlightState | null {
+function parseRawAircraft(
+  raw: RawAircraft,
+  options?: ParseOptions,
+): FlightState | null {
   // Reject non-ICAO addresses (TIS-B, etc.)
   if (!isValidIcaoHex(raw.hex)) return null;
 
@@ -211,11 +218,13 @@ function parseRawAircraft(raw: RawAircraft): FlightState | null {
   }
 
   const { altitude, onGround } = parseAltBaro(raw.alt_baro);
+  const responseTime =
+    normalizeFlightTimestamp(options?.responseTime) ?? Date.now();
 
   return {
     icao24: raw.hex.toLowerCase(),
     callsign: optionalTrimmedString(raw.flight),
-    originCountry: countryFromRegistration(raw.r),
+    registrationCountry: countryFromRegistration(raw.r),
     longitude: raw.lon,
     latitude: raw.lat,
     baroAltitude: altitude,
@@ -246,6 +255,15 @@ function parseRawAircraft(raw: RawAircraft): FlightState | null {
     category: readsbCategoryToNumber(raw.category),
     typeCode: optionalTrimmedString(raw.t),
     registration: optionalTrimmedString(raw.r),
+    provenance: createFlightProvenance({
+      positionProvider: options?.positionProvider ?? "unknown",
+      responseTime,
+      observationTime:
+        typeof raw.seen_pos === "number"
+          ? responseTime - raw.seen_pos * 1000
+          : null,
+      positionAgeSeconds: raw.seen_pos,
+    }),
 
     // ── Avionics (readsb-only, will be undefined for OpenSky) ──────
     ias: optionalFinite(raw.ias),
@@ -311,6 +329,10 @@ export interface ParseOptions {
   includeGround?: boolean;
   /** Require barometric altitude. Default: true. */
   requireBaroAltitude?: boolean;
+  /** Provider that supplied this response. */
+  positionProvider?: string;
+  /** Provider response time in Unix seconds or milliseconds. */
+  responseTime?: number;
 }
 
 /**
@@ -329,7 +351,7 @@ export function parseAircraftList(
 
   for (const raw of rawList) {
     if (!raw || typeof raw !== "object") continue;
-    const state = parseRawAircraft(raw);
+    const state = parseRawAircraft(raw, options);
     if (!state) continue;
 
     // Filter ground aircraft unless specifically requested

--- a/src/lib/flight-api.ts
+++ b/src/lib/flight-api.ts
@@ -28,6 +28,7 @@ export {
   fetchFlightsByPoint,
   fetchFlightByHex,
   fetchFlightByCallsign,
+  fetchSelectedAircraftFromAdsbLol,
   getProviderOverride,
   setProviderOverride,
   PROVIDER_CHANGE_EVENT,

--- a/src/lib/flight-provenance.test.ts
+++ b/src/lib/flight-provenance.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createFlightProvenance,
+  normalizeFlightTimestamp,
+} from "./flight-provenance";
+import { parseStates } from "./opensky-parsing";
+
+test("normalizes second and millisecond flight timestamps", () => {
+  assert.equal(normalizeFlightTimestamp(1_700_000_000), 1_700_000_000_000);
+  assert.equal(
+    normalizeFlightTimestamp(1_700_000_000_250),
+    1_700_000_000_250,
+  );
+  assert.equal(normalizeFlightTimestamp(Number.NaN), null);
+});
+
+test("preserves provider identity and position age", () => {
+  assert.deepEqual(
+    createFlightProvenance({
+      positionProvider: "adsb.lol",
+      responseTime: 1_700_000_010_000,
+      observationTime: 1_700_000_008_000,
+    }),
+    {
+      responseTime: 1_700_000_010_000,
+      observationTime: 1_700_000_008_000,
+      positionAgeSeconds: 2,
+      contributingSources: ["adsb.lol"],
+      positionProvider: "adsb.lol",
+    },
+  );
+});
+
+test("uses OpenSky response and position timestamps", () => {
+  const flight = parseStates(
+    {
+      time: 1_700_000_010,
+      states: [
+        [
+          "abc123",
+          "TST123",
+          "United States",
+          1_700_000_008,
+          1_700_000_009,
+          -122.4,
+          37.7,
+          10_000,
+          false,
+          220,
+          90,
+          0,
+          null,
+          10_100,
+          "1200",
+          false,
+          0,
+          3,
+        ],
+      ],
+    },
+    { includeGround: true, requireBaroAltitude: false },
+  )[0];
+
+  assert.equal(flight.provenance.responseTime, 1_700_000_010_000);
+  assert.equal(flight.provenance.observationTime, 1_700_000_008_000);
+  assert.equal(flight.provenance.positionAgeSeconds, 2);
+  assert.equal(flight.provenance.positionProvider, "opensky");
+});

--- a/src/lib/flight-provenance.ts
+++ b/src/lib/flight-provenance.ts
@@ -1,0 +1,47 @@
+import type { FlightProvenance } from "./opensky-types";
+
+const SECONDS_TIMESTAMP_LIMIT = 10_000_000_000;
+
+export function normalizeFlightTimestamp(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+  return Math.round(
+    value < SECONDS_TIMESTAMP_LIMIT ? value * 1000 : value,
+  );
+}
+
+export function createFlightProvenance({
+  positionProvider,
+  responseTime,
+  observationTime,
+  positionAgeSeconds,
+}: {
+  positionProvider: string;
+  responseTime: unknown;
+  observationTime?: unknown;
+  positionAgeSeconds?: unknown;
+}): FlightProvenance {
+  const normalizedResponseTime =
+    normalizeFlightTimestamp(responseTime) ?? Date.now();
+  const normalizedObservationTime = normalizeFlightTimestamp(observationTime);
+  const explicitAge =
+    typeof positionAgeSeconds === "number" &&
+    Number.isFinite(positionAgeSeconds) &&
+    positionAgeSeconds >= 0
+      ? positionAgeSeconds
+      : null;
+  const derivedAge =
+    normalizedObservationTime !== null
+      ? Math.max(0, (normalizedResponseTime - normalizedObservationTime) / 1000)
+      : null;
+  const provider = positionProvider.trim() || "unknown";
+
+  return {
+    responseTime: normalizedResponseTime,
+    observationTime: normalizedObservationTime,
+    positionAgeSeconds: explicitAge ?? derivedAge,
+    contributingSources: [provider],
+    positionProvider: provider,
+  };
+}

--- a/src/lib/opensky-parsing.ts
+++ b/src/lib/opensky-parsing.ts
@@ -5,6 +5,7 @@ import type {
   RateLimitInfo,
 } from "./opensky-types";
 import { ICAO24_REGEX, clamp } from "./opensky-types";
+import { createFlightProvenance } from "./flight-provenance";
 
 // ── Header Parsing ─────────────────────────────────────────────────────
 
@@ -70,6 +71,7 @@ function openskyPositionSource(
 
 export function parseStateRow(
   rawState: (string | number | boolean | null)[],
+  options?: Pick<ParseStateOptions, "positionProvider" | "responseTime">,
 ): FlightState | null {
   if (!Array.isArray(rawState) || rawState.length < 18) return null;
 
@@ -89,7 +91,8 @@ export function parseStateRow(
     icao24,
     callsign:
       typeof rawState[1] === "string" ? rawState[1].trim() || null : null,
-    originCountry: typeof rawState[2] === "string" ? rawState[2] : "Unknown",
+    registrationCountry:
+      typeof rawState[2] === "string" ? rawState[2] : null,
     longitude,
     latitude,
     baroAltitude,
@@ -102,6 +105,11 @@ export function parseStateRow(
     spiFlag: rawState[15] === true,
     positionSource: openskyPositionSource(rawState[16]),
     category: isFiniteNumber(rawState[17]) ? rawState[17] : null,
+    provenance: createFlightProvenance({
+      positionProvider: options?.positionProvider ?? "opensky",
+      responseTime: options?.responseTime ?? Date.now(),
+      observationTime: rawState[3],
+    }),
   };
 }
 
@@ -115,7 +123,12 @@ export function parseStates(
   const requireBaroAltitude = options?.requireBaroAltitude ?? true;
 
   return raw.states
-    .map(parseStateRow)
+    .map((state) =>
+      parseStateRow(state, {
+        positionProvider: options?.positionProvider ?? "opensky",
+        responseTime: options?.responseTime ?? raw.time,
+      }),
+    )
     .filter((state): state is FlightState => state !== null)
     .filter(
       (f) =>

--- a/src/lib/opensky-types.ts
+++ b/src/lib/opensky-types.ts
@@ -35,10 +35,23 @@ export type PositionSource =
   | "other"
   | null;
 
+export type FlightProvenance = {
+  /** Provider response time as Unix milliseconds */
+  responseTime: number;
+  /** Time of the position observation as Unix milliseconds */
+  observationTime: number | null;
+  /** Age of the position when the provider built its response */
+  positionAgeSeconds: number | null;
+  /** All sources that supplied fields in this state */
+  contributingSources: string[];
+  /** Provider that supplied the selected position and motion group */
+  positionProvider: string;
+};
+
 export type FlightState = {
   icao24: string;
   callsign: string | null;
-  originCountry: string;
+  registrationCountry: string | null;
   longitude: number | null;
   latitude: number | null;
   baroAltitude: number | null;
@@ -57,6 +70,16 @@ export type FlightState = {
   typeCode?: string | null;
   /** Aircraft registration (e.g. "N12345", "G-KELS") - available from readsb */
   registration?: string | null;
+  /** Two-letter registration country code from the local registry */
+  registrationCountryCode?: string | null;
+  /** Registration country flag from the local registry */
+  registrationCountryFlag?: string | null;
+  /** Aircraft model from the local registry */
+  model?: string | null;
+  /** Aircraft manufacturer from the local registry */
+  manufacturer?: string | null;
+  /** Source and observation timing for this state */
+  provenance: FlightProvenance;
 
   // ── Avionics Data (readsb only, omitted by OpenSky) ──────────────
 
@@ -172,6 +195,8 @@ export type OpenSkyResponse = {
 export type ParseStateOptions = {
   includeGround?: boolean;
   requireBaroAltitude?: boolean;
+  positionProvider?: string;
+  responseTime?: number;
 };
 
 export type RateLimitInfo = {

--- a/src/lib/opensky.ts
+++ b/src/lib/opensky.ts
@@ -10,6 +10,7 @@
 // ── Types ──────────────────────────────────────────────────────────────
 export type {
   FlightState,
+  FlightProvenance,
   FlightDebugData,
   PositionSource,
   FetchResult,

--- a/src/lib/route-lookup.test.ts
+++ b/src/lib/route-lookup.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { clearRouteCache, lookupRoute } from "./route-lookup";
+import {
+  clearRouteCache,
+  lookupRoute,
+  routeCacheKey,
+  type RouteRequest,
+} from "./route-lookup";
 
 function jsonResponse(body: unknown, init?: ResponseInit) {
   return new Response(JSON.stringify(body), {
@@ -11,79 +16,102 @@ function jsonResponse(body: unknown, init?: ResponseInit) {
   });
 }
 
-test("lookupRoute fetches route data through the internal route API", async () => {
+function request(
+  callsign = "UAL123",
+  observationTime = 1_700_000_000_000,
+): RouteRequest {
+  return {
+    callsign,
+    icao24: "abc123",
+    latitude: 37.7,
+    longitude: -122.4,
+    altitudeMeters: 3_000,
+    onGround: false,
+    observationTime,
+  };
+}
+
+function responseBody(input: RouteRequest) {
+  return {
+    callsign: input.callsign,
+    icao24: input.icao24,
+    origin: {
+      iata: "SFO",
+      icao: "KSFO",
+      name: "San Francisco International Airport",
+      municipality: "San Francisco",
+      countryIso: "US",
+      latitude: 37.618999,
+      longitude: -122.375,
+    },
+    destination: {
+      iata: "LHR",
+      icao: "EGLL",
+      name: "London Heathrow Airport",
+      municipality: "London",
+      countryIso: "GB",
+      latitude: 51.4706,
+      longitude: -0.461941,
+    },
+    source: "adsbdb",
+    sources: ["adsbdb", "opensky"],
+    validation: "valid",
+    validatedAt: 1_779_840_000_100,
+    fetchedAt: 1_779_840_000_000,
+  };
+}
+
+test("lookupRoute sends bounded aircraft context to the internal API", async () => {
   clearRouteCache();
   const originalFetch = globalThis.fetch;
   const urls: string[] = [];
-
-  globalThis.fetch = (async (input: RequestInfo | URL) => {
-    const url = String(input);
-    urls.push(url);
-
-    if (url === "/api/routes?callsign=UAL123") {
-      return jsonResponse({
-        callsign: "UAL123",
-        origin: {
-          iata: "SFO",
-          icao: "KSFO",
-          name: "San Francisco International Airport",
-          municipality: "San Francisco",
-          countryIso: "US",
-          latitude: 37.618999,
-          longitude: -122.375,
-        },
-        destination: {
-          iata: "LHR",
-          icao: "EGLL",
-          name: "London Heathrow Airport",
-          municipality: "London",
-          countryIso: "GB",
-          latitude: 51.4706,
-          longitude: -0.461941,
-        },
-        source: "adsbdb",
-        fetchedAt: 1_779_840_000_000,
-      });
-    }
-
-    return jsonResponse({ status: "404", error: "not found" }, { status: 404 });
+  const input = request();
+  globalThis.fetch = (async (url: RequestInfo | URL) => {
+    urls.push(String(url));
+    return jsonResponse(responseBody(input));
   }) as typeof fetch;
 
   try {
-    const route = await lookupRoute("ual123");
-
+    const route = await lookupRoute(input);
     assert.equal(route?.source, "adsbdb");
-    assert.equal(route?.origin?.iata, "SFO");
-    assert.equal(route?.destination?.iata, "LHR");
-    assert.deepEqual(urls, ["/api/routes?callsign=UAL123"]);
+    assert.deepEqual(route?.sources, ["adsbdb", "opensky"]);
+    assert.equal(route?.validation, "valid");
+    const query = new URL(urls[0], "https://aeris.example").searchParams;
+    assert.equal(query.get("callsign"), "UAL123");
+    assert.equal(query.get("icao24"), "abc123");
+    assert.equal(query.get("latitude"), "37.7");
+    assert.equal(query.get("longitude"), "-122.4");
+    assert.equal(query.get("altitudeMeters"), "3000");
+    assert.equal(query.get("onGround"), "0");
+    assert.equal(query.get("observationTime"), "1700000000000");
   } finally {
     globalThis.fetch = originalFetch;
     clearRouteCache();
   }
 });
 
+test("route cache keys include hex, callsign, and six-hour bucket", () => {
+  const first = request("UAL123", 1_700_000_000_000);
+  const sameBucket = request("UAL123", first.observationTime + 60_000);
+  const nextBucket = request("UAL123", first.observationTime + 6 * 60 * 60_000);
+  assert.equal(routeCacheKey(first), routeCacheKey(sameBucket));
+  assert.notEqual(routeCacheKey(first), routeCacheKey(nextBucket));
+  assert.notEqual(routeCacheKey(first), routeCacheKey({ ...first, icao24: "def456" }));
+});
+
 test("lookupRoute caches internal route API misses", async () => {
   clearRouteCache();
   const originalFetch = globalThis.fetch;
   let requestCount = 0;
-
-  globalThis.fetch = (async (input: RequestInfo | URL) => {
-    const url = String(input);
-    requestCount += 1;
-
-    if (url === "/api/routes?callsign=NOPE123") {
-      return jsonResponse({ error: "Route unavailable" }, { status: 404 });
-    }
-
-    return jsonResponse({ status: "404", error: "not found" }, { status: 404 });
+  globalThis.fetch = (async () => {
+    requestCount++;
+    return jsonResponse({ error: "Route unavailable" }, { status: 404 });
   }) as typeof fetch;
 
   try {
-    const first = await lookupRoute("NOPE123");
-    const second = await lookupRoute("NOPE123");
-
-    assert.equal(first, null);
-    assert.equal(second, null);
+    const input = request("NOPE123");
+    assert.equal(await lookupRoute(input), null);
+    assert.equal(await lookupRoute(input), null);
     assert.equal(requestCount, 1);
   } finally {
     globalThis.fetch = originalFetch;
@@ -95,9 +123,8 @@ test("lookupRoute does not cache temporary route API failures", async () => {
   clearRouteCache();
   const originalFetch = globalThis.fetch;
   let requestCount = 0;
-
   globalThis.fetch = (async () => {
-    requestCount += 1;
+    requestCount++;
     return jsonResponse(
       { error: "Route lookup temporarily unavailable" },
       { status: 503 },
@@ -105,11 +132,9 @@ test("lookupRoute does not cache temporary route API failures", async () => {
   }) as typeof fetch;
 
   try {
-    const first = await lookupRoute("UAL790");
-    const second = await lookupRoute("UAL790");
-
-    assert.equal(first, null);
-    assert.equal(second, null);
+    const input = request("UAL790");
+    assert.equal(await lookupRoute(input), null);
+    assert.equal(await lookupRoute(input), null);
     assert.equal(requestCount, 2);
   } finally {
     globalThis.fetch = originalFetch;
@@ -117,22 +142,24 @@ test("lookupRoute does not cache temporary route API failures", async () => {
   }
 });
 
-test("lookupRoute does not cache malformed route API success bodies", async () => {
+test("lookupRoute treats malformed success bodies as temporary misses", async () => {
   clearRouteCache();
   const originalFetch = globalThis.fetch;
   let requestCount = 0;
-
   globalThis.fetch = (async () => {
-    requestCount += 1;
-    return jsonResponse({ callsign: "UAL791", source: "adsbdb" });
+    requestCount++;
+    return requestCount === 1
+      ? new Response("", { status: 201 })
+      : new Response("<html>wait</html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        });
   }) as typeof fetch;
 
   try {
-    const first = await lookupRoute("UAL791");
-    const second = await lookupRoute("UAL791");
-
-    assert.equal(first, null);
-    assert.equal(second, null);
+    const input = request("UAL791");
+    assert.equal(await lookupRoute(input), null);
+    assert.equal(await lookupRoute(input), null);
     assert.equal(requestCount, 2);
   } finally {
     globalThis.fetch = originalFetch;

--- a/src/lib/route-lookup.ts
+++ b/src/lib/route-lookup.ts
@@ -1,46 +1,37 @@
-// Route Lookup Client
-//
-// Client-side callers resolve route data through Aeris' own /api/routes
-// endpoint. The server endpoint owns external provider validation, rate
-// limiting, cache headers, and upstream normalization.
-//
-// IMPORTANT: Only verified routes from external databases are shown.
-// No predicted, observed, or interpolated routes are ever displayed.
+import type { RoutePositionContext } from "./route-validation";
 
 export type RouteAirport = {
-  /** IATA code, e.g. "LHR" */
   iata: string;
-  /** ICAO code, e.g. "EGLL" */
   icao: string;
-  /** Airport name, e.g. "London Heathrow Airport" */
   name: string;
-  /** City/municipality, e.g. "London" */
   municipality: string;
-  /** ISO country code, e.g. "GB" */
   countryIso: string;
-  /** Latitude in degrees */
   latitude: number;
-  /** Longitude in degrees */
   longitude: number;
 };
 
+export type RouteSource = "adsbdb" | "hexdb" | "opensky";
+
 export type RouteInfo = {
-  /** The callsign this route was looked up for */
   callsign: string;
-  /** Origin airport */
+  icao24: string;
   origin: RouteAirport | null;
-  /** Destination airport */
   destination: RouteAirport | null;
-  /** Data source that resolved this route */
-  source: "adsbdb" | "hexdb" | "opensky";
-  /** When this entry was fetched (for TTL) */
+  source: RouteSource;
+  sources: RouteSource[];
+  validation: "valid";
+  validatedAt: number;
   fetchedAt: number;
 };
 
-const CACHE_HIT_TTL_MS = 15 * 60_000;
-const CACHE_MISS_TTL_MS = 2 * 60_000;
+export type RouteRequest = RoutePositionContext;
+
+const CACHE_HIT_TTL_MS = 5 * 60_000;
+const CACHE_MISS_TTL_MS = 60_000;
 const CACHE_MAX_ENTRIES = 300;
-const CALLSIGN_RE = /^[A-Z0-9]{1,8}$/i;
+const SIX_HOURS_MS = 6 * 60 * 60_000;
+const CALLSIGN_RE = /^[A-Z0-9]{1,8}$/;
+const ICAO24_RE = /^[0-9a-f]{6}$/;
 
 type CacheEntry = {
   route: RouteInfo | null;
@@ -50,28 +41,51 @@ type CacheEntry = {
 const cache = new Map<string, CacheEntry>();
 const inflight = new Map<string, Promise<RouteInfo | null>>();
 
-function normalizeCallsign(callsign: string | null | undefined): string | null {
-  if (!callsign) return null;
-  const normalized = callsign.trim().toUpperCase();
-  return normalized && CALLSIGN_RE.test(normalized) ? normalized : null;
+export function normalizeRouteRequest(
+  request: RouteRequest,
+): RouteRequest | null {
+  const callsign = request.callsign.trim().toUpperCase();
+  const icao24 = request.icao24.trim().toLowerCase();
+  if (!CALLSIGN_RE.test(callsign) || !ICAO24_RE.test(icao24)) return null;
+  if (
+    !Number.isFinite(request.latitude) ||
+    request.latitude < -90 ||
+    request.latitude > 90 ||
+    !Number.isFinite(request.longitude) ||
+    request.longitude < -180 ||
+    request.longitude > 180 ||
+    !Number.isFinite(request.observationTime) ||
+    request.observationTime <= 0 ||
+    (request.altitudeMeters !== null &&
+      (!Number.isFinite(request.altitudeMeters) ||
+        request.altitudeMeters < -1_000 ||
+        request.altitudeMeters > 30_000))
+  ) {
+    return null;
+  }
+  return { ...request, callsign, icao24 };
 }
 
-function cacheGet(callsign: string): RouteInfo | null | undefined {
-  const entry = cache.get(callsign);
+export function routeCacheKey(request: RouteRequest): string {
+  const bucket = Math.floor(request.observationTime / SIX_HOURS_MS);
+  return `${request.icao24}:${request.callsign}:${bucket}`;
+}
+
+function cacheGet(key: string): RouteInfo | null | undefined {
+  const entry = cache.get(key);
   if (!entry) return undefined;
   if (Date.now() > entry.expiresAt) {
-    cache.delete(callsign);
+    cache.delete(key);
     return undefined;
   }
   return entry.route;
 }
 
-function cacheSet(callsign: string, route: RouteInfo | null): void {
-  cache.set(callsign, {
+function cacheSet(key: string, route: RouteInfo | null): void {
+  cache.set(key, {
     route,
     expiresAt: Date.now() + (route ? CACHE_HIT_TTL_MS : CACHE_MISS_TTL_MS),
   });
-
   if (cache.size > CACHE_MAX_ENTRIES) {
     const first = cache.keys().next();
     if (!first.done) cache.delete(first.value);
@@ -89,23 +103,38 @@ function isRouteAirport(value: unknown): value is RouteAirport {
     typeof airport.countryIso === "string" &&
     typeof airport.latitude === "number" &&
     Number.isFinite(airport.latitude) &&
+    airport.latitude >= -90 &&
+    airport.latitude <= 90 &&
     typeof airport.longitude === "number" &&
-    Number.isFinite(airport.longitude)
+    Number.isFinite(airport.longitude) &&
+    airport.longitude >= -180 &&
+    airport.longitude <= 180
   );
 }
 
-function parseRouteInfo(value: unknown): RouteInfo | null {
+function parseRouteInfo(value: unknown, request: RouteRequest): RouteInfo | null {
   if (typeof value !== "object" || value === null) return null;
   const route = value as Record<string, unknown>;
-
-  if (typeof route.callsign !== "string") return null;
+  if (route.callsign !== request.callsign || route.icao24 !== request.icao24) {
+    return null;
+  }
   if (
     route.source !== "adsbdb" &&
     route.source !== "hexdb" &&
     route.source !== "opensky"
-  )
+  ) {
     return null;
+  }
   if (
+    !Array.isArray(route.sources) ||
+    route.sources.length === 0 ||
+    !route.sources.every(
+      (source) =>
+        source === "adsbdb" || source === "hexdb" || source === "opensky",
+    ) ||
+    route.validation !== "valid" ||
+    typeof route.validatedAt !== "number" ||
+    !Number.isFinite(route.validatedAt) ||
     typeof route.fetchedAt !== "number" ||
     !Number.isFinite(route.fetchedAt)
   ) {
@@ -114,64 +143,67 @@ function parseRouteInfo(value: unknown): RouteInfo | null {
 
   const origin = route.origin === null ? null : route.origin;
   const destination = route.destination === null ? null : route.destination;
-
-  if (origin !== null && !isRouteAirport(origin)) return null;
-  if (destination !== null && !isRouteAirport(destination)) return null;
-
-  // Require both origin and destination for a verified route
-  if (origin === null || destination === null) return null;
+  if (!isRouteAirport(origin) || !isRouteAirport(destination)) return null;
 
   return {
-    callsign: route.callsign,
+    callsign: request.callsign,
+    icao24: request.icao24,
     origin,
     destination,
     source: route.source,
+    sources: [...new Set(route.sources)] as RouteSource[],
+    validation: "valid",
+    validatedAt: route.validatedAt,
     fetchedAt: route.fetchedAt,
   };
 }
 
 export async function lookupRoute(
-  callsign: string | null | undefined,
+  input: RouteRequest,
   signal?: AbortSignal,
 ): Promise<RouteInfo | null> {
-  const normalized = normalizeCallsign(callsign);
-  if (!normalized) return null;
-
-  const cached = cacheGet(normalized);
+  const request = normalizeRouteRequest(input);
+  if (!request) return null;
+  const key = routeCacheKey(request);
+  const cached = cacheGet(key);
   if (cached !== undefined) return cached;
-
-  const existing = inflight.get(normalized);
+  const existing = inflight.get(key);
   if (existing) return existing;
+
+  const query = new URLSearchParams({
+    callsign: request.callsign,
+    icao24: request.icao24,
+    latitude: String(request.latitude),
+    longitude: String(request.longitude),
+    altitudeMeters:
+      request.altitudeMeters === null ? "" : String(request.altitudeMeters),
+    onGround: request.onGround ? "1" : "0",
+    observationTime: String(request.observationTime),
+  });
 
   const promise = (async (): Promise<RouteInfo | null> => {
     try {
-      const response = await fetch(
-        `/api/routes?callsign=${encodeURIComponent(normalized)}`,
-        {
-          headers: { Accept: "application/json" },
-          signal,
-        },
-      );
-
-      if (response.status === 400 || response.status === 404) {
-        cacheSet(normalized, null);
+      const response = await fetch(`/api/routes?${query}`, {
+        headers: { Accept: "application/json" },
+        signal,
+      });
+      if (response.status === 404) {
+        cacheSet(key, null);
         return null;
       }
-
       if (!response.ok) return null;
-
-      const route = parseRouteInfo(await response.json());
-      if (route) cacheSet(normalized, route);
+      const route = parseRouteInfo(await response.json(), request);
+      if (route) cacheSet(key, route);
       return route;
-    } catch (err) {
-      if (err instanceof DOMException && err.name === "AbortError") return null;
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") return null;
       return null;
     } finally {
-      inflight.delete(normalized);
+      inflight.delete(key);
     }
   })();
 
-  inflight.set(normalized, promise);
+  inflight.set(key, promise);
   return promise;
 }
 

--- a/src/lib/route-resolver.test.ts
+++ b/src/lib/route-resolver.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   clearRouteResolverCache,
   resolveRouteFromOpenDatabases,
+  resolveRouteFromOpenDatabasesDetailed,
 } from "./route-resolver";
 
 function jsonResponse(body: unknown, init?: ResponseInit) {
@@ -12,6 +13,18 @@ function jsonResponse(body: unknown, init?: ResponseInit) {
     headers: { "content-type": "application/json" },
     ...init,
   });
+}
+
+function routeContext(callsign: string) {
+  return {
+    callsign,
+    icao24: "abc123",
+    latitude: 37.7,
+    longitude: -122.4,
+    altitudeMeters: 10_000,
+    onGround: false,
+    observationTime: 1_700_000_000_000,
+  };
 }
 
 test("resolveRouteFromOpenDatabases uses direct hexdb fallback after adsbdb misses", async () => {
@@ -61,7 +74,7 @@ test("resolveRouteFromOpenDatabases uses direct hexdb fallback after adsbdb miss
   }) as typeof fetch;
 
   try {
-    const route = await resolveRouteFromOpenDatabases("UAL123");
+    const route = await resolveRouteFromOpenDatabases(routeContext("UAL123"));
 
     assert.equal(route?.source, "hexdb");
     assert.equal(route?.origin?.iata, "SFO");
@@ -102,7 +115,7 @@ test("resolveRouteFromOpenDatabases returns null when all route databases miss",
   }) as typeof fetch;
 
   try {
-    const route = await resolveRouteFromOpenDatabases("UAL456");
+    const route = await resolveRouteFromOpenDatabases(routeContext("UAL456"));
 
     assert.equal(route, null);
     assert.ok(urls.includes("https://hexdb.io/api/v1/route/icao/UAL456"));
@@ -141,8 +154,8 @@ test("resolveRouteFromOpenDatabases caches provider 404 misses", async () => {
   }) as typeof fetch;
 
   try {
-    const first = await resolveRouteFromOpenDatabases("UAL457");
-    const second = await resolveRouteFromOpenDatabases("UAL457");
+    const first = await resolveRouteFromOpenDatabases(routeContext("UAL457"));
+    const second = await resolveRouteFromOpenDatabases(routeContext("UAL457"));
 
     assert.equal(first, null);
     assert.equal(second, null);
@@ -164,12 +177,66 @@ test("resolveRouteFromOpenDatabases does not cache transient provider failures",
   }) as typeof fetch;
 
   try {
-    const first = await resolveRouteFromOpenDatabases("UAL458");
-    const second = await resolveRouteFromOpenDatabases("UAL458");
+    const first = await resolveRouteFromOpenDatabases(routeContext("UAL458"));
+    const second = await resolveRouteFromOpenDatabases(routeContext("UAL458"));
 
     assert.equal(first, null);
     assert.equal(second, null);
     assert.equal(requestCount, 6);
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearRouteResolverCache();
+  }
+});
+
+test("route providers treat empty 201, HTML, and invalid JSON as temporary", async () => {
+  clearRouteResolverCache();
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes("api.adsbdb.com")) {
+      return new Response("", {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.includes("hexdb.io")) {
+      return new Response("<html>wait</html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      });
+    }
+    return new Response("not-json", {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  try {
+    const resolution = await resolveRouteFromOpenDatabasesDetailed(
+      routeContext("UAL459"),
+    );
+    assert.equal(resolution.route, null);
+    assert.equal(resolution.temporarilyUnavailable, true);
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearRouteResolverCache();
+  }
+});
+
+test("route provider timeouts remain temporary", async () => {
+  clearRouteResolverCache();
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    throw new DOMException("Timed out", "TimeoutError");
+  }) as typeof fetch;
+
+  try {
+    const resolution = await resolveRouteFromOpenDatabasesDetailed(
+      routeContext("UAL460"),
+    );
+    assert.equal(resolution.route, null);
+    assert.equal(resolution.temporarilyUnavailable, true);
   } finally {
     globalThis.fetch = originalFetch;
     clearRouteResolverCache();
@@ -203,7 +270,7 @@ test("resolveRouteFromOpenDatabases prefers opensky when it returns first", asyn
   }) as typeof fetch;
 
   try {
-    const route = await resolveRouteFromOpenDatabases("BAW123");
+    const route = await resolveRouteFromOpenDatabases(routeContext("BAW123"));
 
     assert.equal(route?.source, "opensky");
     assert.equal(route?.origin?.icao, "EGLL");

--- a/src/lib/route-resolver.ts
+++ b/src/lib/route-resolver.ts
@@ -1,17 +1,24 @@
-import type { RouteAirport, RouteInfo } from "./route-lookup";
+import {
+  routeCacheKey,
+  type RouteAirport,
+  type RouteInfo,
+  type RouteSource,
+} from "./route-lookup";
+import {
+  validateReportedRoute,
+  type RoutePositionContext,
+} from "./route-validation";
 import { findAirportByIcao } from "./airports";
 
 const ADSBDB_BASE = "https://api.adsbdb.com/v0";
 const HEXDB_BASE = "https://hexdb.io/api/v1";
 const OPEN_SKY_ROUTES_BASE = "https://opensky-network.org/api";
 
-const CACHE_HIT_TTL_MS = 15 * 60_000;
-const CACHE_MISS_TTL_MS = 2 * 60_000;
+const CACHE_HIT_TTL_MS = 5 * 60_000;
+const CACHE_MISS_TTL_MS = 60_000;
 const CACHE_MAX_ENTRIES = 500;
 
 const PROVIDER_TIMEOUT_MS = 6_000;
-
-type RouteSource = "adsbdb" | "hexdb" | "opensky";
 
 const PROVIDER_RATE_LIMIT_MS: Record<RouteSource, number> = {
   adsbdb: 1_100,
@@ -24,6 +31,7 @@ const CALLSIGN_RE = /^[A-Z0-9]{1,8}$/i;
 export type RouteResolution = {
   route: RouteInfo | null;
   temporarilyUnavailable: boolean;
+  validationConflict: boolean;
 };
 
 export function normalizeRouteCallsign(
@@ -54,18 +62,18 @@ const providerQueues: Record<RouteSource, Promise<void>> = {
   opensky: Promise.resolve(),
 };
 
-function cacheGet(callsign: string): RouteInfo | null | undefined {
-  const entry = cache.get(callsign);
+function cacheGet(key: string): RouteInfo | null | undefined {
+  const entry = cache.get(key);
   if (!entry) return undefined;
   if (Date.now() > entry.expiresAt) {
-    cache.delete(callsign);
+    cache.delete(key);
     return undefined;
   }
   return entry.route;
 }
 
-function cacheSet(callsign: string, route: RouteInfo | null): void {
-  cache.set(callsign, {
+function cacheSet(key: string, route: RouteInfo | null): void {
+  cache.set(key, {
     route,
     expiresAt: Date.now() + (route ? CACHE_HIT_TTL_MS : CACHE_MISS_TTL_MS),
   });
@@ -148,9 +156,14 @@ async function fetchProviderJson(
 }
 
 type ProviderRouteResult = {
-  route: RouteInfo | null;
+  route: ProviderRoute | null;
   cacheableMiss: boolean;
 };
+
+type ProviderRoute = Pick<
+  RouteInfo,
+  "callsign" | "origin" | "destination" | "source" | "fetchedAt"
+>;
 
 // ── ADSBDB ──────────────────────────────────────────────────────────────
 
@@ -172,7 +185,19 @@ function parseAdsbdbAirport(
   if (!raw) return null;
   const iata = raw.iata_code?.trim();
   const icao = raw.icao_code?.trim();
-  if (!iata && !icao) return null;
+  if (
+    (!iata && !icao) ||
+    typeof raw.latitude !== "number" ||
+    !Number.isFinite(raw.latitude) ||
+    raw.latitude < -90 ||
+    raw.latitude > 90 ||
+    typeof raw.longitude !== "number" ||
+    !Number.isFinite(raw.longitude) ||
+    raw.longitude < -180 ||
+    raw.longitude > 180
+  ) {
+    return null;
+  }
 
   return {
     iata: iata ?? "",
@@ -180,14 +205,8 @@ function parseAdsbdbAirport(
     name: raw.name?.trim() ?? "",
     municipality: raw.municipality?.trim() ?? "",
     countryIso: raw.country_iso_name?.trim() ?? "",
-    latitude:
-      typeof raw.latitude === "number" && Number.isFinite(raw.latitude)
-        ? raw.latitude
-        : 0,
-    longitude:
-      typeof raw.longitude === "number" && Number.isFinite(raw.longitude)
-        ? raw.longitude
-        : 0,
+    latitude: raw.latitude,
+    longitude: raw.longitude,
   };
 }
 
@@ -217,7 +236,7 @@ async function fetchFromAdsbdb(callsign: string): Promise<ProviderRouteResult> {
     route.destination as AdsbdbAirport | null,
   );
 
-  // Require both origin and destination for a verified route
+  // Require both endpoints for a complete reported route.
   if (!origin || !destination) {
     return { route: null, cacheableMiss: true };
   }
@@ -244,6 +263,18 @@ function parseHexdbAirport(
   const obj = raw as Record<string, unknown>;
 
   if (typeof obj.status === "string" && obj.status === "404") return null;
+  if (
+    typeof obj.latitude !== "number" ||
+    !Number.isFinite(obj.latitude) ||
+    obj.latitude < -90 ||
+    obj.latitude > 90 ||
+    typeof obj.longitude !== "number" ||
+    !Number.isFinite(obj.longitude) ||
+    obj.longitude < -180 ||
+    obj.longitude > 180
+  ) {
+    return null;
+  }
 
   return {
     iata: typeof obj.iata === "string" ? obj.iata.trim() : "",
@@ -253,14 +284,8 @@ function parseHexdbAirport(
       typeof obj.region_name === "string" ? obj.region_name.trim() : "",
     countryIso:
       typeof obj.country_code === "string" ? obj.country_code.trim() : "",
-    latitude:
-      typeof obj.latitude === "number" && Number.isFinite(obj.latitude)
-        ? obj.latitude
-        : 0,
-    longitude:
-      typeof obj.longitude === "number" && Number.isFinite(obj.longitude)
-        ? obj.longitude
-        : 0,
+    latitude: obj.latitude,
+    longitude: obj.longitude,
   };
 }
 
@@ -366,8 +391,8 @@ async function fetchFromOpenSky(callsign: string): Promise<ProviderRouteResult> 
   const originAirport = findAirportByIcao(originIcao);
   const destAirport = findAirportByIcao(destinationIcao);
 
-  // OpenSky returns ICAO codes only. We need both airports in our DB
-  // to produce a verified route with full metadata.
+  // OpenSky returns ICAO codes only. We need both airports in our database
+  // to produce a complete reported route.
   if (!originAirport || !destAirport) {
     return { route: null, cacheableMiss: true };
   }
@@ -396,70 +421,122 @@ async function fetchFromOpenSky(callsign: string): Promise<ProviderRouteResult> 
 
 // ── Resolver ────────────────────────────────────────────────────────────
 
+function routeEndpoints(route: ProviderRoute): string {
+  const origin = route.origin?.icao || route.origin?.iata || "";
+  const destination =
+    route.destination?.icao || route.destination?.iata || "";
+  return `${origin}:${destination}`;
+}
+
+function selectValidRoute(
+  routes: ProviderRoute[],
+  context: RoutePositionContext,
+): RouteInfo | null {
+  for (const route of routes) {
+    if (!route.origin || !route.destination) continue;
+    const validation = validateReportedRoute(
+      route.origin,
+      route.destination,
+      context,
+    );
+    if (!validation.valid) continue;
+    const endpoints = routeEndpoints(route);
+    const sources = routes
+      .filter((candidate) => routeEndpoints(candidate) === endpoints)
+      .map((candidate) => candidate.source);
+    return {
+      ...route,
+      icao24: context.icao24,
+      sources: [...new Set(sources)],
+      validation: "valid",
+      validatedAt: Date.now(),
+    };
+  }
+  return null;
+}
+
 export async function resolveRouteFromOpenDatabases(
-  callsign: string | null | undefined,
+  context: RoutePositionContext,
 ): Promise<RouteInfo | null> {
-  const resolution = await resolveRouteFromOpenDatabasesDetailed(callsign);
+  const resolution = await resolveRouteFromOpenDatabasesDetailed(context);
   return resolution.route;
 }
 
 export async function resolveRouteFromOpenDatabasesDetailed(
-  callsign: string | null | undefined,
+  context: RoutePositionContext,
 ): Promise<RouteResolution> {
-  const normalized = normalizeRouteCallsign(callsign);
-  if (!normalized) return { route: null, temporarilyUnavailable: false };
+  const normalized = normalizeRouteCallsign(context.callsign);
+  const icao24 = context.icao24.trim().toLowerCase();
+  if (!normalized || !/^[0-9a-f]{6}$/.test(icao24)) {
+    return {
+      route: null,
+      temporarilyUnavailable: false,
+      validationConflict: false,
+    };
+  }
+  const normalizedContext = { ...context, callsign: normalized, icao24 };
+  const key = routeCacheKey(normalizedContext);
 
-  const cached = cacheGet(normalized);
+  const cached = cacheGet(key);
   if (cached !== undefined) {
-    return { route: cached, temporarilyUnavailable: false };
+    return {
+      route: cached,
+      temporarilyUnavailable: false,
+      validationConflict: false,
+    };
   }
 
-  const existing = inflight.get(normalized);
+  const existing = inflight.get(key);
   if (existing) return existing;
 
   const promise = (async () => {
     try {
-      // Fetch all three sources in parallel for speed.
-      // Each source has its own rate limiter so we won't exceed limits.
       const [adsbdbResult, hexdbResult, openskyResult] = await Promise.all([
         fetchFromAdsbdb(normalized),
         fetchFromHexdb(normalized),
         fetchFromOpenSky(normalized),
       ]);
 
-      // Return the first verified route we get
-      if (adsbdbResult.route) {
-        cacheSet(normalized, adsbdbResult.route);
-        return { route: adsbdbResult.route, temporarilyUnavailable: false };
-      }
-      if (hexdbResult.route) {
-        cacheSet(normalized, hexdbResult.route);
-        return { route: hexdbResult.route, temporarilyUnavailable: false };
-      }
-      if (openskyResult.route) {
-        cacheSet(normalized, openskyResult.route);
-        return { route: openskyResult.route, temporarilyUnavailable: false };
+      const routes = [
+        adsbdbResult.route,
+        hexdbResult.route,
+        openskyResult.route,
+      ].filter((route): route is ProviderRoute => route !== null);
+      if (routes.length > 0) {
+        const route = selectValidRoute(routes, normalizedContext);
+        cacheSet(key, route);
+        return {
+          route,
+          temporarilyUnavailable: false,
+          validationConflict: route === null,
+        };
       }
 
-      // All returned cacheable misses → route genuinely unknown
       const allCacheable =
         adsbdbResult.cacheableMiss &&
         hexdbResult.cacheableMiss &&
         openskyResult.cacheableMiss;
 
       if (allCacheable) {
-        cacheSet(normalized, null);
-        return { route: null, temporarilyUnavailable: false };
+        cacheSet(key, null);
+        return {
+          route: null,
+          temporarilyUnavailable: false,
+          validationConflict: false,
+        };
       }
 
-      // At least one provider errored → transient failure
-      return { route: null, temporarilyUnavailable: true };
+      return {
+        route: null,
+        temporarilyUnavailable: true,
+        validationConflict: false,
+      };
     } finally {
-      inflight.delete(normalized);
+      inflight.delete(key);
     }
   })();
 
-  inflight.set(normalized, promise);
+  inflight.set(key, promise);
   return promise;
 }
 

--- a/src/lib/route-validation.test.ts
+++ b/src/lib/route-validation.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { RouteAirport } from "./route-lookup";
+import { validateReportedRoute } from "./route-validation";
+
+const sfo: RouteAirport = {
+  iata: "SFO",
+  icao: "KSFO",
+  name: "San Francisco International Airport",
+  municipality: "San Francisco",
+  countryIso: "US",
+  latitude: 37.618999,
+  longitude: -122.375,
+};
+
+const jfk: RouteAirport = {
+  iata: "JFK",
+  icao: "KJFK",
+  name: "John F. Kennedy International Airport",
+  municipality: "New York",
+  countryIso: "US",
+  latitude: 40.639801,
+  longitude: -73.7789,
+};
+
+function context(
+  latitude: number,
+  longitude: number,
+  altitudeMeters = 10_668,
+  onGround = false,
+) {
+  return {
+    icao24: "abc123",
+    callsign: "DAL1598",
+    latitude,
+    longitude,
+    altitudeMeters,
+    onGround,
+    observationTime: 1_700_000_000_000,
+  };
+}
+
+test("accepts an aircraft inside the bounded route corridor", () => {
+  const result = validateReportedRoute(
+    sfo,
+    jfk,
+    context(39.5, -98.5),
+  );
+  assert.equal(result.valid, true);
+  assert.ok(result.corridorToleranceNm >= 50);
+  assert.ok(result.corridorToleranceNm <= 250);
+});
+
+test("rejects a DAL1598-style conflicting SFO route", () => {
+  const result = validateReportedRoute(
+    sfo,
+    jfk,
+    context(33.6407, -84.4277),
+  );
+  assert.equal(result.valid, false);
+  assert.equal(result.reason, "corridor");
+});
+
+test("requires a ground aircraft to be within fifteen nautical miles", () => {
+  assert.equal(
+    validateReportedRoute(sfo, jfk, context(37.62, -122.38, 0, true)).valid,
+    true,
+  );
+  const result = validateReportedRoute(
+    sfo,
+    jfk,
+    context(37.95, -121.95, 0, true),
+  );
+  assert.equal(result.valid, false);
+  assert.equal(result.reason, "ground-endpoint");
+});
+
+test("requires a low aircraft to be near a route endpoint", () => {
+  const result = validateReportedRoute(
+    sfo,
+    jfk,
+    context(39.5, -98.5, 2_000),
+  );
+  assert.equal(result.valid, false);
+  assert.equal(result.reason, "low-endpoint");
+});

--- a/src/lib/route-validation.ts
+++ b/src/lib/route-validation.ts
@@ -1,0 +1,158 @@
+import type { RouteAirport } from "./route-lookup";
+
+const EARTH_RADIUS_NM = 3_440.065;
+const FEET_TO_METERS = 0.3048;
+
+export type RoutePositionContext = {
+  icao24: string;
+  callsign: string;
+  latitude: number;
+  longitude: number;
+  altitudeMeters: number | null;
+  onGround: boolean;
+  observationTime: number;
+};
+
+export type RouteValidationResult = {
+  valid: boolean;
+  reason: "valid" | "corridor" | "ground-endpoint" | "low-endpoint";
+  corridorDistanceNm: number;
+  corridorToleranceNm: number;
+  nearestEndpointNm: number;
+};
+
+function radians(value: number): number {
+  return (value * Math.PI) / 180;
+}
+
+function angularDistance(
+  first: { latitude: number; longitude: number },
+  second: { latitude: number; longitude: number },
+): number {
+  const firstLatitude = radians(first.latitude);
+  const secondLatitude = radians(second.latitude);
+  const latitudeDelta = secondLatitude - firstLatitude;
+  const longitudeDelta = radians(second.longitude - first.longitude);
+  const haversine =
+    Math.sin(latitudeDelta / 2) ** 2 +
+    Math.cos(firstLatitude) *
+      Math.cos(secondLatitude) *
+      Math.sin(longitudeDelta / 2) ** 2;
+  return 2 * Math.atan2(Math.sqrt(haversine), Math.sqrt(1 - haversine));
+}
+
+function initialBearing(
+  first: { latitude: number; longitude: number },
+  second: { latitude: number; longitude: number },
+): number {
+  const firstLatitude = radians(first.latitude);
+  const secondLatitude = radians(second.latitude);
+  const longitudeDelta = radians(second.longitude - first.longitude);
+  return Math.atan2(
+    Math.sin(longitudeDelta) * Math.cos(secondLatitude),
+    Math.cos(firstLatitude) * Math.sin(secondLatitude) -
+      Math.sin(firstLatitude) *
+        Math.cos(secondLatitude) *
+        Math.cos(longitudeDelta),
+  );
+}
+
+export function distanceNm(
+  first: { latitude: number; longitude: number },
+  second: { latitude: number; longitude: number },
+): number {
+  return angularDistance(first, second) * EARTH_RADIUS_NM;
+}
+
+export function distanceToRouteCorridorNm(
+  position: { latitude: number; longitude: number },
+  origin: RouteAirport,
+  destination: RouteAirport,
+): number {
+  const routeDistance = angularDistance(origin, destination);
+  if (routeDistance === 0) return distanceNm(position, origin);
+
+  const originToPosition = angularDistance(origin, position);
+  const routeBearing = initialBearing(origin, destination);
+  const positionBearing = initialBearing(origin, position);
+  const bearingDelta = positionBearing - routeBearing;
+  const crossTrack = Math.asin(
+    Math.sin(originToPosition) * Math.sin(bearingDelta),
+  );
+  const alongTrack = Math.atan2(
+    Math.sin(originToPosition) * Math.cos(bearingDelta),
+    Math.cos(originToPosition),
+  );
+
+  if (alongTrack < 0 || alongTrack > routeDistance) {
+    return Math.min(
+      distanceNm(position, origin),
+      distanceNm(position, destination),
+    );
+  }
+  return Math.abs(crossTrack) * EARTH_RADIUS_NM;
+}
+
+export function validateReportedRoute(
+  origin: RouteAirport,
+  destination: RouteAirport,
+  context: RoutePositionContext,
+): RouteValidationResult {
+  const position = {
+    latitude: context.latitude,
+    longitude: context.longitude,
+  };
+  const routeDistanceNm = distanceNm(origin, destination);
+  const corridorToleranceNm = Math.min(
+    250,
+    Math.max(50, routeDistanceNm * 0.15),
+  );
+  const corridorDistanceNm = distanceToRouteCorridorNm(
+    position,
+    origin,
+    destination,
+  );
+  const nearestEndpointNm = Math.min(
+    distanceNm(position, origin),
+    distanceNm(position, destination),
+  );
+
+  if (corridorDistanceNm > corridorToleranceNm) {
+    return {
+      valid: false,
+      reason: "corridor",
+      corridorDistanceNm,
+      corridorToleranceNm,
+      nearestEndpointNm,
+    };
+  }
+  if (context.onGround && nearestEndpointNm > 15) {
+    return {
+      valid: false,
+      reason: "ground-endpoint",
+      corridorDistanceNm,
+      corridorToleranceNm,
+      nearestEndpointNm,
+    };
+  }
+  if (
+    context.altitudeMeters !== null &&
+    context.altitudeMeters < 10_000 * FEET_TO_METERS &&
+    nearestEndpointNm > 150
+  ) {
+    return {
+      valid: false,
+      reason: "low-endpoint",
+      corridorDistanceNm,
+      corridorToleranceNm,
+      nearestEndpointNm,
+    };
+  }
+  return {
+    valid: true,
+    reason: "valid",
+    corridorDistanceNm,
+    corridorToleranceNm,
+    nearestEndpointNm,
+  };
+}

--- a/src/lib/selected-aircraft.test.ts
+++ b/src/lib/selected-aircraft.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { AircraftRegistryRecord } from "./aircraft-registry";
+import type { FlightState } from "./opensky-types";
+import {
+  clearSelectedAircraftCacheForTests,
+  fuseSelectedAircraft,
+  loadSelectedAircraftSources,
+  selectCoherentFlightState,
+} from "./selected-aircraft";
+
+function makeFlight(
+  provider: string,
+  observationTime: number,
+  overrides: Partial<FlightState> = {},
+): FlightState {
+  return {
+    icao24: "abc123",
+    callsign: "TST123",
+    registrationCountry: null,
+    longitude: 77.6,
+    latitude: 12.5,
+    baroAltitude: 9_144,
+    onGround: false,
+    velocity: 220,
+    trueTrack: 90,
+    verticalRate: 0,
+    geoAltitude: 9_200,
+    squawk: "1200",
+    spiFlag: false,
+    positionSource: "adsb",
+    category: 3,
+    provenance: {
+      responseTime: observationTime + 500,
+      observationTime,
+      positionAgeSeconds: 0.5,
+      contributingSources: [provider],
+      positionProvider: provider,
+    },
+    ...overrides,
+  };
+}
+
+test("uses quality as a tie-breaker within two seconds", () => {
+  const current = makeFlight("airplanes.live", 10_000, {
+    debugData: {
+      nic: 9,
+      nacP: 10,
+      nacV: null,
+      sil: null,
+      version: 2,
+      alert: null,
+      messages: null,
+      seen: null,
+      rssi: null,
+    },
+  });
+  const fresh = makeFlight("adsb.lol", 11_000, {
+    longitude: 78,
+    debugData: {
+      nic: 8,
+      nacP: 8,
+      nacV: null,
+      sil: null,
+      version: 2,
+      alert: null,
+      messages: null,
+      seen: null,
+      rssi: null,
+    },
+  });
+
+  assert.equal(selectCoherentFlightState(current, fresh), current);
+  assert.equal(
+    selectCoherentFlightState(current, makeFlight("adsb.lol", 13_000))
+      .provenance.positionProvider,
+    "adsb.lol",
+  );
+});
+
+test("adds preferred registry metadata and all contributing sources", () => {
+  const current = makeFlight("airplanes.live", 10_000);
+  const fresh = makeFlight("adsb.lol", 13_000);
+  const registry: AircraftRegistryRecord = {
+    icao24: "abc123",
+    registration: "N100",
+    typeCode: "C172",
+    model: "172K",
+    manufacturer: "CESSNA",
+    registrationCountry: "United States",
+    registrationCountryCode: "US",
+    registrationCountryFlag: "🇺🇸",
+    databaseFlags: "00",
+    sources: ["faa", "mictronics"],
+  };
+
+  const result = fuseSelectedAircraft(current, fresh, registry, 20_000);
+  assert.equal(result.flight.registration, "N100");
+  assert.equal(result.flight.model, "172K");
+  assert.equal(result.flight.manufacturer, "CESSNA");
+  assert.equal(result.flight.registrationCountry, "United States");
+  assert.deepEqual(result.contributingSources, [
+    "airplanes.live",
+    "adsb.lol",
+    "faa",
+    "mictronics",
+  ]);
+});
+
+test("caches partial selected-aircraft results for thirty seconds", async () => {
+  clearSelectedAircraftCacheForTests();
+  let freshRequests = 0;
+  let registryRequests = 0;
+  const dependencies = {
+    fetchFresh: async () => {
+      freshRequests++;
+      throw new Error("temporary failure");
+    },
+    lookupRegistry: async () => {
+      registryRequests++;
+      return null;
+    },
+    now: () => 10_000,
+  };
+
+  const first = await loadSelectedAircraftSources(
+    "abc123",
+    undefined,
+    dependencies,
+  );
+  const second = await loadSelectedAircraftSources(
+    "abc123",
+    undefined,
+    dependencies,
+  );
+  assert.equal(first.fresh, null);
+  assert.equal(second, first);
+  assert.equal(freshRequests, 1);
+  assert.equal(registryRequests, 1);
+  clearSelectedAircraftCacheForTests();
+});
+
+test("cancels stale selected-aircraft requests", async () => {
+  clearSelectedAircraftCacheForTests();
+  const controller = new AbortController();
+  const waitForAbort = (_value: string, signal?: AbortSignal) =>
+    new Promise<null>((_resolve, reject) => {
+      signal?.addEventListener(
+        "abort",
+        () => reject(new DOMException("Aborted", "AbortError")),
+        { once: true },
+      );
+    });
+  const request = loadSelectedAircraftSources("abc123", controller.signal, {
+    fetchFresh: waitForAbort,
+    lookupRegistry: waitForAbort,
+  });
+  controller.abort();
+  await assert.rejects(request, { name: "AbortError" });
+  clearSelectedAircraftCacheForTests();
+});

--- a/src/lib/selected-aircraft.test.ts
+++ b/src/lib/selected-aircraft.test.ts
@@ -79,6 +79,58 @@ test("uses quality as a tie-breaker within two seconds", () => {
   );
 });
 
+test("keeps timing and provider with the selected position group", () => {
+  const current = makeFlight("airplanes.live", 10_000, {
+    provenance: {
+      responseTime: 12_000,
+      observationTime: 10_000,
+      positionAgeSeconds: 2,
+      contributingSources: ["airplanes.live"],
+      positionProvider: "airplanes.live",
+    },
+    debugData: {
+      nic: 9,
+      nacP: 10,
+      nacV: null,
+      sil: null,
+      version: 2,
+      alert: null,
+      messages: null,
+      seen: null,
+      rssi: null,
+    },
+  });
+  const fresh = makeFlight("adsb.lol", 11_000, {
+    provenance: {
+      responseTime: 20_000,
+      observationTime: 11_000,
+      positionAgeSeconds: 9,
+      contributingSources: ["adsb.lol"],
+      positionProvider: "adsb.lol",
+    },
+    debugData: {
+      nic: 8,
+      nacP: 8,
+      nacV: null,
+      sil: null,
+      version: 2,
+      alert: null,
+      messages: null,
+      seen: null,
+      rssi: null,
+    },
+  });
+
+  const result = fuseSelectedAircraft(current, fresh, null, 25_000);
+  assert.equal(result.flight.provenance.responseTime, 12_000);
+  assert.equal(result.flight.provenance.observationTime, 10_000);
+  assert.equal(result.flight.provenance.positionAgeSeconds, 2);
+  assert.equal(
+    result.flight.provenance.positionProvider,
+    "airplanes.live",
+  );
+});
+
 test("adds preferred registry metadata and all contributing sources", () => {
   const current = makeFlight("airplanes.live", 10_000);
   const fresh = makeFlight("adsb.lol", 13_000);

--- a/src/lib/selected-aircraft.ts
+++ b/src/lib/selected-aircraft.ts
@@ -114,10 +114,7 @@ export function fuseSelectedAircraft(
       current.registrationCountryFlag ??
       null,
     provenance: {
-      responseTime: Math.max(
-        current.provenance.responseTime,
-        fresh?.provenance.responseTime ?? 0,
-      ),
+      responseTime: position.provenance.responseTime,
       observationTime: position.provenance.observationTime,
       positionAgeSeconds: position.provenance.positionAgeSeconds,
       contributingSources: sources,

--- a/src/lib/selected-aircraft.ts
+++ b/src/lib/selected-aircraft.ts
@@ -1,0 +1,171 @@
+import type { AircraftRegistryRecord } from "./aircraft-registry";
+import { lookupAircraftRegistry } from "./aircraft-registry";
+import { fetchSelectedAircraftFromAdsbLol } from "./flight-api-client";
+import type { FlightState } from "./opensky-types";
+
+const SELECTED_AIRCRAFT_CACHE_TTL_MS = 30_000;
+
+export type SelectedAircraftSources = {
+  icao24: string;
+  fresh: FlightState | null;
+  registry: AircraftRegistryRecord | null;
+  fetchedAt: number;
+};
+
+export type SelectedAircraftFusionResult = {
+  flight: FlightState;
+  registry: AircraftRegistryRecord | null;
+  contributingSources: string[];
+  fusedAt: number;
+};
+
+type SelectedAircraftCacheEntry = {
+  expiresAt: number;
+  sources: SelectedAircraftSources;
+};
+
+const selectedAircraftCache = new Map<string, SelectedAircraftCacheEntry>();
+
+function observationTime(flight: FlightState): number {
+  const provenance = flight.provenance;
+  if (provenance.observationTime !== null) return provenance.observationTime;
+  if (provenance.positionAgeSeconds !== null) {
+    return provenance.responseTime - provenance.positionAgeSeconds * 1000;
+  }
+  return provenance.responseTime;
+}
+
+function qualityTuple(flight: FlightState): [number, number, number] {
+  return [
+    flight.debugData?.nacP ?? -1,
+    flight.debugData?.nic ?? -1,
+    flight.positionSource === "adsb" ? 1 : 0,
+  ];
+}
+
+function compareQuality(left: FlightState, right: FlightState): number {
+  const leftQuality = qualityTuple(left);
+  const rightQuality = qualityTuple(right);
+  for (let index = 0; index < leftQuality.length; index++) {
+    if (leftQuality[index] !== rightQuality[index]) {
+      return leftQuality[index] - rightQuality[index];
+    }
+  }
+  return 0;
+}
+
+export function selectCoherentFlightState(
+  current: FlightState,
+  fresh: FlightState | null,
+): FlightState {
+  if (!fresh) return current;
+  const currentTime = observationTime(current);
+  const freshTime = observationTime(fresh);
+  if (Math.abs(freshTime - currentTime) <= 2_000) {
+    const quality = compareQuality(fresh, current);
+    if (quality !== 0) return quality > 0 ? fresh : current;
+  }
+  return freshTime >= currentTime ? fresh : current;
+}
+
+function uniqueSources(...groups: (readonly string[] | undefined)[]): string[] {
+  return [...new Set(groups.flatMap((group) => group ?? []))];
+}
+
+export function fuseSelectedAircraft(
+  current: FlightState,
+  fresh: FlightState | null,
+  registry: AircraftRegistryRecord | null,
+  fusedAt = Date.now(),
+): SelectedAircraftFusionResult {
+  const position = selectCoherentFlightState(current, fresh);
+  const sources = uniqueSources(
+    current.provenance.contributingSources,
+    fresh?.provenance.contributingSources,
+    registry?.sources,
+  );
+
+  const flight: FlightState = {
+    ...position,
+    callsign: fresh?.callsign ?? current.callsign,
+    registration:
+      registry?.registration ?? fresh?.registration ?? current.registration,
+    typeCode: registry?.typeCode ?? fresh?.typeCode ?? current.typeCode,
+    typeDescription:
+      fresh?.typeDescription ?? current.typeDescription ?? null,
+    model: registry?.model ?? fresh?.model ?? current.model ?? null,
+    manufacturer:
+      registry?.manufacturer ??
+      fresh?.manufacturer ??
+      current.manufacturer ??
+      null,
+    registrationCountry:
+      registry?.registrationCountry ??
+      fresh?.registrationCountry ??
+      current.registrationCountry,
+    registrationCountryCode:
+      registry?.registrationCountryCode ??
+      fresh?.registrationCountryCode ??
+      current.registrationCountryCode ??
+      null,
+    registrationCountryFlag:
+      registry?.registrationCountryFlag ??
+      fresh?.registrationCountryFlag ??
+      current.registrationCountryFlag ??
+      null,
+    provenance: {
+      responseTime: Math.max(
+        current.provenance.responseTime,
+        fresh?.provenance.responseTime ?? 0,
+      ),
+      observationTime: position.provenance.observationTime,
+      positionAgeSeconds: position.provenance.positionAgeSeconds,
+      contributingSources: sources,
+      positionProvider: position.provenance.positionProvider,
+    },
+  };
+
+  return { flight, registry, contributingSources: sources, fusedAt };
+}
+
+export async function loadSelectedAircraftSources(
+  icao24: string,
+  signal?: AbortSignal,
+  dependencies: {
+    fetchFresh?: typeof fetchSelectedAircraftFromAdsbLol;
+    lookupRegistry?: typeof lookupAircraftRegistry;
+    now?: () => number;
+  } = {},
+): Promise<SelectedAircraftSources> {
+  const normalized = icao24.trim().toLowerCase();
+  const now = dependencies.now ?? Date.now;
+  const cached = selectedAircraftCache.get(normalized);
+  if (cached && now() < cached.expiresAt) return cached.sources;
+  if (signal?.aborted) throw new DOMException("Aborted", "AbortError");
+
+  const fetchFresh = dependencies.fetchFresh ?? fetchSelectedAircraftFromAdsbLol;
+  const lookupRegistry = dependencies.lookupRegistry ?? lookupAircraftRegistry;
+  const [freshResult, registryResult] = await Promise.allSettled([
+    fetchFresh(normalized, signal),
+    lookupRegistry(normalized, signal),
+  ]);
+  if (signal?.aborted) throw new DOMException("Aborted", "AbortError");
+
+  const fetchedAt = now();
+  const sources: SelectedAircraftSources = {
+    icao24: normalized,
+    fresh: freshResult.status === "fulfilled" ? freshResult.value : null,
+    registry:
+      registryResult.status === "fulfilled" ? registryResult.value : null,
+    fetchedAt,
+  };
+  selectedAircraftCache.set(normalized, {
+    expiresAt: fetchedAt + SELECTED_AIRCRAFT_CACHE_TTL_MS,
+    sources,
+  });
+  return sources;
+}
+
+export function clearSelectedAircraftCacheForTests(): void {
+  selectedAircraftCache.clear();
+}


### PR DESCRIPTION
## Summary

- Preserve response time, observation time, position age, and provider identity.
- Fetch one fresh adsb.lol hex result when an aircraft is selected.
- Fuse the current map record, the fresh result, and local registry data.
- Keep timing and provider identity with the selected coherent position group.
- Prefer FAA metadata for US registrations and Mictronics metadata elsewhere.
- Record all contributing sources. Cancel stale requests and cache selected-aircraft results for 30 seconds.
- Send bounded aircraft context to route lookup and label results as `Reported route`.
- Hide routes that conflict with corridor, endpoint, altitude, or ground-state checks.
- Cache positive route results for five minutes and negative results for one minute.
- Keep the existing OpenSky fallback unchanged. Do not add adsb.fi fan-out for selected aircraft.
- Do not store ADSBDB route snapshots.

## Stack

- Stack position: 2 of 3
- PR base: `data/open-aviation-data`
- Base commit: `d6d80ff9aaa1877e152fbaa025ef9dff14c486c8`
- Previous PR: #40
- Next PR: #42
- Changelog impact: PR #42 contains the single consolidated `0.8.9` entry to prevent stack conflicts.

## Verification

- `pnpm test:data` with 11 passing tests on the full stack
- `pnpm data:check` with 496,914 aircraft and 72,490 airports
- `pnpm test` with 351 passing tests on the full stack
- `pnpm lint` with no errors and four existing warnings
- `pnpm build`
- Coherent timing and provider regression coverage
- DAL1598-style incorrect SFO route regression coverage

## Production safety

- `main` is production.
- Keep this PR as a draft and unmerged for review.
- Do not enable auto-merge or deploy from this PR.
