### PR TITLE
Simplify the aircraft details sidebar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aeris",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aeris",
-      "version": "0.8.8",
+      "version": "0.8.9",
       "license": "AGPL-3.0",
       "dependencies": {
         "@deck.gl/core": "^9.2.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aeris",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "Real-time 3D flight tracking - altitude-aware, visually stunning.",
   "author": "kewonit",
   "license": "AGPL-3.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -133,13 +133,12 @@
 
 @layer components {
   .aeris-map-surface {
-    transform: translate3d(0, 0, 0);
-    transform-origin: left center;
+    left: 0;
     box-shadow: none;
-    transition-property: transform, border-radius;
-    transition-duration: 660ms;
+    transition-property: left, border-radius;
+    transition-duration: 640ms;
     transition-timing-function: cubic-bezier(0.19, 1, 0.22, 1);
-    will-change: transform;
+    will-change: left, border-radius;
     contain: layout paint style;
     isolation: isolate;
     backface-visibility: hidden;
@@ -160,13 +159,9 @@
 
   @media (min-width: 640px) {
     .aeris-map-surface[data-panel-open="true"] {
-      border-top-left-radius: 2.5rem;
-      border-bottom-left-radius: 2.5rem;
-      transform: translate3d(
-        calc(var(--aeris-left-sidebar-width) - 4px),
-        0,
-        0
-      );
+      left: calc(var(--aeris-left-sidebar-width) - 4px);
+      border-top-left-radius: 2rem;
+      border-bottom-left-radius: 2rem;
     }
 
     .aeris-left-chrome[data-panel-open="true"] {

--- a/src/components/flight-tracker.tsx
+++ b/src/components/flight-tracker.tsx
@@ -15,6 +15,10 @@ import { useTheme } from "@wrksz/themes/client";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { Map as MapView } from "@/components/map/map";
 import { CameraController } from "@/components/map/camera-controller";
+import {
+  CLOSED_MAP_PANEL_CAMERA_STATE,
+  createMapPanelCameraState,
+} from "@/components/map/panel-camera";
 import { AirportLayer } from "@/components/map/airport-layer";
 import { AirspaceLayer } from "@/components/map/airspace-layer";
 import { WeatherRadarLayer } from "@/components/map/weather-radar-layer";
@@ -303,6 +307,28 @@ function FlightTrackerInner({
 
   const fpvFlightOrCached = fpvFlight;
   const displayFlight = selectedFlight;
+  const [retainedDesktopFlight, setRetainedDesktopFlight] =
+    useState<FlightState | null>(displayFlight);
+
+  useEffect(() => {
+    if (displayFlight) {
+      const timeout = window.setTimeout(
+        () => setRetainedDesktopFlight(displayFlight),
+        0,
+      );
+      return () => window.clearTimeout(timeout);
+    }
+
+    if (selectedIcao24) return;
+    const timeout = window.setTimeout(() => setRetainedDesktopFlight(null), 0);
+    return () => window.clearTimeout(timeout);
+  }, [displayFlight, selectedIcao24]);
+
+  const desktopPanelFlight =
+    displayFlight ??
+    (retainedDesktopFlight?.icao24 === selectedIcao24
+      ? retainedDesktopFlight
+      : null);
 
   // ── Airport Board state ──────────────────────────────────────────────
   const airportBoard = useAirportBoard(
@@ -329,11 +355,13 @@ function FlightTrackerInner({
       const nextIcao24 = selectedIcao24 === icao24 ? null : icao24;
       setSelectedIcao24(nextIcao24);
       if (nextIcao24) {
+        const nextFlight = displayFlightMap.get(nextIcao24);
+        if (nextFlight) setRetainedDesktopFlight(nextFlight);
         setSelectedAirportIata(null);
         if (!isMobile) setLeftPanel({ kind: "flight" });
       }
     },
-    [isMobile, selectedIcao24],
+    [displayFlightMap, isMobile, selectedIcao24],
   );
 
   const handleAirportBoardClose = useCallback(() => {
@@ -355,6 +383,7 @@ function FlightTrackerInner({
         const icao24 = info.object.icao24.toLowerCase();
         const nextIcao24 = selectedIcao24 === icao24 ? null : icao24;
         setSelectedIcao24(nextIcao24);
+        if (nextIcao24) setRetainedDesktopFlight(info.object);
         setSelectedAirportIata(null);
         if (!isMobile) {
           setLeftPanel(nextIcao24 ? { kind: "flight" } : null);
@@ -482,6 +511,7 @@ function FlightTrackerInner({
   const selectFlight = useCallback(
     (f: FlightState, enterFpv = false) => {
       setSelectedIcao24(f.icao24);
+      setRetainedDesktopFlight(f);
       setFollowIcao24(null);
       setSelectedAirportIata(null);
       if (
@@ -611,6 +641,39 @@ function FlightTrackerInner({
   const showMobileAirportCard =
     isMobile && !fpvIcao24 && !displayFlight && airportBoard.isActive;
   const desktopLeftPanelOpen = !isMobile && !fpvIcao24 && leftPanel !== null;
+  const panelCamera = useMemo(() => {
+    if (!desktopLeftPanelOpen || !leftPanel) {
+      return CLOSED_MAP_PANEL_CAMERA_STATE;
+    }
+
+    if (leftPanel.kind === "flight") {
+      return createMapPanelCameraState({
+        kind: "flight",
+        focusKey: desktopPanelFlight
+          ? `flight:${desktopPanelFlight.icao24}`
+          : null,
+        longitude: desktopPanelFlight?.longitude,
+        latitude: desktopPanelFlight?.latitude,
+        altitudeMeters:
+          desktopPanelFlight?.baroAltitude ?? desktopPanelFlight?.geoAltitude,
+      });
+    }
+
+    return createMapPanelCameraState({
+      kind: "airport",
+      focusKey: airportBoard.airport
+        ? `airport:${airportBoard.airport.iata}`
+        : null,
+      longitude: airportBoard.airport?.lng,
+      latitude: airportBoard.airport?.lat,
+      altitudeMeters: 0,
+    });
+  }, [
+    airportBoard.airport,
+    desktopLeftPanelOpen,
+    desktopPanelFlight,
+    leftPanel,
+  ]);
   const desktopPanelStyle = {
     "--aeris-left-sidebar-width": AERIS_LEFT_SIDEBAR_WIDTH,
     "--aeris-left-chrome-shift": `calc(${AERIS_LEFT_SIDEBAR_WIDTH} + 0.25rem)`,
@@ -623,7 +686,7 @@ function FlightTrackerInner({
       style={desktopPanelStyle}
     >
       <div
-        className="aeris-map-surface absolute inset-0 z-0 overflow-hidden bg-background"
+        className="aeris-map-surface absolute bottom-0 right-0 top-0 z-0 overflow-hidden bg-background"
         data-panel-open={desktopLeftPanelOpen}
       >
         <MapView
@@ -637,6 +700,7 @@ function FlightTrackerInner({
             followFlight={followFlight}
             fpvFlight={fpvFlightOrCached}
             fpvPositionRef={fpvPositionRef}
+            panelCamera={panelCamera}
           />
           <AirportLayer
             activeCity={activeCity}
@@ -689,7 +753,7 @@ function FlightTrackerInner({
           <AerisLeftSidebar
             leftPanel={leftPanel}
             onClose={() => setLeftPanel(null)}
-            displayFlight={displayFlight}
+            displayFlight={desktopPanelFlight}
             selectedTrail={selectedTrail}
             selectedTrack={selectedTrack}
             onCloseFlight={handleDeselectFlight}

--- a/src/components/map/camera-controller-utils.ts
+++ b/src/components/map/camera-controller-utils.ts
@@ -103,6 +103,46 @@ export function projectLngLatElevationPixelDelta(
   return null;
 }
 
+export function centerLngLatForScreenOffset(
+  map: maplibregl.Map,
+  lng: number,
+  lat: number,
+  offset: [number, number],
+): [number, number] | null {
+  type TransformLike = {
+    center: maplibregl.LngLat;
+    centerPoint: { x: number; y: number };
+    clone: () => TransformLike;
+    setLocationAtPoint: (
+      lnglat: maplibregl.LngLat,
+      point: maplibregl.Point,
+    ) => void;
+  };
+
+  const transform = (map as unknown as { transform?: TransformLike }).transform;
+  if (!transform || typeof transform.clone !== "function") return null;
+
+  try {
+    const clone = transform.clone();
+    clone.setLocationAtPoint(
+      new maplibregl.LngLat(lng, lat),
+      new maplibregl.Point(
+        clone.centerPoint.x + offset[0],
+        clone.centerPoint.y + offset[1],
+      ),
+    );
+
+    const center = clone.center;
+    if (!Number.isFinite(center.lng) || !Number.isFinite(center.lat)) {
+      return null;
+    }
+
+    return [center.lng, center.lat];
+  } catch {
+    return null;
+  }
+}
+
 export function setMapInteractionsEnabled(
   map: maplibregl.Map,
   enabled: boolean,

--- a/src/components/map/camera-controller.tsx
+++ b/src/components/map/camera-controller.tsx
@@ -2,13 +2,25 @@
 
 import { useEffect, useRef, type MutableRefObject } from "react";
 import { useMap } from "./map";
-import { smoothstep } from "./camera-controller-utils";
+import {
+  centerLngLatForScreenOffset,
+  projectLngLatElevationPixelDelta,
+  smoothstep,
+} from "./camera-controller-utils";
+import { getZoomAdjustedElevationScale } from "./altitude-projection";
 import { useSettings } from "@/hooks/use-settings";
 import type { City } from "@/lib/cities";
 import type { FlightState } from "@/lib/opensky";
+import { altitudeToElevation } from "@/lib/flight-utils";
 import { useFpvCamera } from "./use-fpv-camera";
 import { useKeyboardCamera } from "./use-keyboard-camera";
 import { useOrbitCamera } from "./use-orbit-camera";
+import {
+  coordinatesMatch,
+  panelVisualOffset,
+  shouldCenterMapPanel,
+  type MapPanelCameraState,
+} from "./panel-camera";
 
 const DEFAULT_ZOOM = 9.2;
 const DEFAULT_PITCH = 49;
@@ -16,6 +28,10 @@ const DEFAULT_BEARING = 27.4;
 const FOLLOW_ZOOM = 10.5;
 const FOLLOW_PITCH = 55;
 const FOLLOW_EASE_MS = 2000;
+const CITY_FLY_MS = 2800;
+const PANEL_EASE_MS = 640;
+const PANEL_VISUAL_EASE_MS = 320;
+const PANEL_VISUAL_REFINEMENT_MS = 220;
 
 type FpvPosition = { lng: number; lat: number; alt: number; track: number };
 
@@ -24,11 +40,13 @@ export function CameraController({
   followFlight = null,
   fpvFlight = null,
   fpvPositionRef,
+  panelCamera,
 }: {
   city: City;
   followFlight?: FlightState | null;
   fpvFlight?: FlightState | null;
   fpvPositionRef?: MutableRefObject<FpvPosition | null>;
+  panelCamera: MapPanelCameraState;
 }) {
   const { map, isLoaded } = useMap();
   const { settings } = useSettings();
@@ -46,6 +64,10 @@ export function CameraController({
   const isFpvActiveRef = useRef(false);
   const fpvFlightRef = useRef<FlightState | null>(fpvFlight);
   const fpvPosRef = useRef(fpvPositionRef);
+  const previousPanelFocusRef = useRef<string | null>(null);
+  const cityTransitionTargetRef = useRef<[number, number] | null>(null);
+  const panelCameraRef = useRef(panelCamera);
+  const hasPanelCoordinates = panelCamera.coordinates !== null;
 
   useEffect(() => {
     fpvPosRef.current = fpvPositionRef;
@@ -55,21 +77,211 @@ export function CameraController({
     fpvFlightRef.current = fpvFlight;
   }, [fpvFlight]);
 
+  useEffect(() => {
+    panelCameraRef.current = panelCamera;
+  }, [panelCamera]);
+
   // City flyTo
   useEffect(() => {
     if (!map || !isLoaded || !city) return;
     if (city.id === prevCityRef.current) return;
 
     prevCityRef.current = city.id;
+    if (panelCamera.open && panelCamera.kind === "flight") {
+      cityTransitionTargetRef.current = null;
+      return;
+    }
+
+    cityTransitionTargetRef.current = city.coordinates;
+    const clearTargetTimer = window.setTimeout(() => {
+      if (coordinatesMatch(cityTransitionTargetRef.current, city.coordinates)) {
+        cityTransitionTargetRef.current = null;
+      }
+    }, 0);
     map.flyTo({
       center: city.coordinates,
       zoom: DEFAULT_ZOOM,
       pitch: DEFAULT_PITCH,
       bearing: DEFAULT_BEARING,
-      duration: 2800,
+      duration: CITY_FLY_MS,
       essential: true,
     });
-  }, [map, isLoaded, city]);
+
+    return () => window.clearTimeout(clearTargetTimer);
+  }, [map, isLoaded, city, panelCamera.open, panelCamera.kind]);
+
+  useEffect(() => {
+    if (!map || !isLoaded) return;
+
+    const activePanel = panelCameraRef.current;
+
+    if (!activePanel.open) {
+      previousPanelFocusRef.current = null;
+      return;
+    }
+
+    if (!shouldCenterMapPanel(previousPanelFocusRef.current, activePanel)) {
+      return;
+    }
+
+    const focusKey = activePanel.focusKey;
+    const coordinates = activePanel.coordinates;
+    if (!focusKey || !coordinates) return;
+
+    const panelJustOpened = previousPanelFocusRef.current === null;
+    const followsCityTransition =
+      activePanel.kind === "airport" &&
+      coordinatesMatch(cityTransitionTargetRef.current, coordinates);
+
+    if (followsCityTransition) {
+      previousPanelFocusRef.current = focusKey;
+      return;
+    }
+
+    let correctionTimer: number | null = null;
+    let refinementTimer: number | null = null;
+    const centerTimer = window.setTimeout(() => {
+      const currentPanel = panelCameraRef.current;
+      if (!currentPanel.open || currentPanel.focusKey !== focusKey) return;
+
+      const currentCoordinates = currentPanel.coordinates;
+      if (!currentCoordinates) return;
+      previousPanelFocusRef.current = focusKey;
+
+      map.easeTo({
+        center: currentCoordinates,
+        duration: PANEL_EASE_MS,
+        essential: true,
+      });
+
+      if (currentPanel.kind !== "flight") return;
+
+      correctionTimer = window.setTimeout(() => {
+        const latestPanel = panelCameraRef.current;
+        if (!latestPanel.open || latestPanel.focusKey !== focusKey) return;
+
+        const latestCoordinates = latestPanel.coordinates;
+        const altitudeMeters = latestPanel.altitudeMeters;
+        if (!latestCoordinates || altitudeMeters == null) return;
+
+        const elevationMeters =
+          altitudeToElevation(
+            altitudeMeters,
+            settings.altitudeDisplayMode,
+          ) *
+          getZoomAdjustedElevationScale(
+            map.getZoom(),
+            settings.altitudeDisplayMode,
+          );
+        const elevatedPoint = projectLngLatElevationPixelDelta(
+          map,
+          latestCoordinates[0],
+          latestCoordinates[1],
+          elevationMeters,
+        );
+        const groundPoint = projectLngLatElevationPixelDelta(
+          map,
+          latestCoordinates[0],
+          latestCoordinates[1],
+          0,
+        );
+        if (!elevatedPoint || !groundPoint) return;
+
+        const canvas = map.getCanvas();
+        const offset = panelVisualOffset(
+          {
+            dx: elevatedPoint.dx - groundPoint.dx,
+            dy: elevatedPoint.dy - groundPoint.dy,
+          },
+          canvas.clientWidth,
+          canvas.clientHeight,
+        );
+        if (Math.abs(offset[0]) < 0.5 && Math.abs(offset[1]) < 0.5) return;
+
+        const correctedCenter = centerLngLatForScreenOffset(
+          map,
+          latestCoordinates[0],
+          latestCoordinates[1],
+          offset,
+        );
+        if (!correctedCenter) return;
+
+        map.easeTo({
+          center: correctedCenter,
+          duration: PANEL_VISUAL_EASE_MS,
+          essential: true,
+        });
+
+        refinementTimer = window.setTimeout(() => {
+          const refinedPanel = panelCameraRef.current;
+          if (!refinedPanel.open || refinedPanel.focusKey !== focusKey) return;
+
+          const refinedCoordinates = refinedPanel.coordinates;
+          const refinedAltitudeMeters = refinedPanel.altitudeMeters;
+          if (!refinedCoordinates || refinedAltitudeMeters == null) return;
+
+          const refinedElevationMeters =
+            altitudeToElevation(
+              refinedAltitudeMeters,
+              settings.altitudeDisplayMode,
+            ) *
+            getZoomAdjustedElevationScale(
+              map.getZoom(),
+              settings.altitudeDisplayMode,
+            );
+          const elevatedResidual = projectLngLatElevationPixelDelta(
+            map,
+            refinedCoordinates[0],
+            refinedCoordinates[1],
+            refinedElevationMeters,
+          );
+          const groundResidual = projectLngLatElevationPixelDelta(
+            map,
+            refinedCoordinates[0],
+            refinedCoordinates[1],
+            0,
+          );
+          if (!elevatedResidual || !groundResidual) return;
+
+          const refinedOffset = panelVisualOffset(
+            {
+              dx: elevatedResidual.dx - groundResidual.dx,
+              dy: elevatedResidual.dy - groundResidual.dy,
+            },
+            canvas.clientWidth,
+            canvas.clientHeight,
+          );
+          const refinedCenter = centerLngLatForScreenOffset(
+            map,
+            refinedCoordinates[0],
+            refinedCoordinates[1],
+            refinedOffset,
+          );
+          if (!refinedCenter) return;
+
+          map.easeTo({
+            center: refinedCenter,
+            duration: PANEL_VISUAL_REFINEMENT_MS,
+            essential: true,
+          });
+        }, PANEL_VISUAL_EASE_MS + 40);
+      }, PANEL_EASE_MS + 80);
+    }, panelJustOpened ? PANEL_EASE_MS : 0);
+
+    return () => {
+      window.clearTimeout(centerTimer);
+      if (correctionTimer !== null) window.clearTimeout(correctionTimer);
+      if (refinementTimer !== null) window.clearTimeout(refinementTimer);
+    };
+  }, [
+    map,
+    isLoaded,
+    panelCamera.open,
+    panelCamera.focusKey,
+    panelCamera.kind,
+    hasPanelCoordinates,
+    settings.altitudeDisplayMode,
+  ]);
 
   // Follow flight init
   useEffect(() => {
@@ -233,6 +445,7 @@ export function CameraController({
     followFlight,
     fpvFlight,
     settings,
+    panelCamera.open,
     isInteractingRef,
     orbitFrameRef,
     idleTimerRef,

--- a/src/components/map/panel-camera.test.ts
+++ b/src/components/map/panel-camera.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CLOSED_MAP_PANEL_CAMERA_STATE,
+  coordinatesMatch,
+  createMapPanelCameraState,
+  panelVisualOffset,
+  shouldCenterMapPanel,
+} from "./panel-camera";
+
+test("panel camera creates a valid aircraft focus", () => {
+  const state = createMapPanelCameraState({
+    kind: "flight",
+    focusKey: "flight:abc123",
+    longitude: -122.4,
+    latitude: 37.8,
+    altitudeMeters: 9_000,
+  });
+
+  assert.deepEqual(state, {
+    open: true,
+    kind: "flight",
+    focusKey: "flight:abc123",
+    coordinates: [-122.4, 37.8],
+    altitudeMeters: 9_000,
+  });
+  assert.equal(shouldCenterMapPanel(null, state), true);
+});
+
+test("panel camera rejects invalid coordinates", () => {
+  const state = createMapPanelCameraState({
+    kind: "flight",
+    focusKey: "flight:abc123",
+    longitude: 181,
+    latitude: 37.8,
+  });
+
+  assert.equal(state.coordinates, null);
+  assert.equal(state.altitudeMeters, null);
+  assert.equal(shouldCenterMapPanel(null, state), false);
+});
+
+test("panel camera does not recenter for repeated observations", () => {
+  const state = createMapPanelCameraState({
+    kind: "flight",
+    focusKey: "flight:abc123",
+    longitude: -122.3,
+    latitude: 37.9,
+  });
+
+  assert.equal(shouldCenterMapPanel("flight:abc123", state), false);
+  assert.equal(
+    shouldCenterMapPanel("flight:abc123", CLOSED_MAP_PANEL_CAMERA_STATE),
+    false,
+  );
+});
+
+test("panel camera recenters when the panel focus changes", () => {
+  const airport = createMapPanelCameraState({
+    kind: "airport",
+    focusKey: "airport:SFO",
+    longitude: -122.379,
+    latitude: 37.6213,
+  });
+
+  assert.equal(shouldCenterMapPanel("flight:abc123", airport), true);
+});
+
+test("coordinate matching tolerates insignificant source precision", () => {
+  assert.equal(
+    coordinatesMatch([-122.4, 37.8], [-122.4000001, 37.8000001]),
+    true,
+  );
+  assert.equal(coordinatesMatch([-122.4, 37.8], [-122.41, 37.8]), false);
+});
+
+test("panel visual offset reverses and bounds the elevation delta", () => {
+  assert.deepEqual(panelVisualOffset({ dx: 40, dy: -60 }, 1_000, 800), [
+    -40,
+    60,
+  ]);
+  assert.deepEqual(panelVisualOffset({ dx: 400, dy: -400 }, 1_000, 800), [
+    -400,
+    400,
+  ]);
+  assert.deepEqual(panelVisualOffset({ dx: 900, dy: -900 }, 1_000, 800), [
+    -680,
+    680,
+  ]);
+});

--- a/src/components/map/panel-camera.ts
+++ b/src/components/map/panel-camera.ts
@@ -1,0 +1,99 @@
+export type MapPanelCameraKind = "flight" | "airport";
+
+export type MapPanelCameraState = {
+  open: boolean;
+  kind: MapPanelCameraKind | null;
+  focusKey: string | null;
+  coordinates: [number, number] | null;
+  altitudeMeters: number | null;
+};
+
+export const CLOSED_MAP_PANEL_CAMERA_STATE: MapPanelCameraState = {
+  open: false,
+  kind: null,
+  focusKey: null,
+  coordinates: null,
+  altitudeMeters: null,
+};
+
+export function createMapPanelCameraState({
+  kind,
+  focusKey,
+  longitude,
+  latitude,
+  altitudeMeters,
+}: {
+  kind: MapPanelCameraKind;
+  focusKey: string | null | undefined;
+  longitude: number | null | undefined;
+  latitude: number | null | undefined;
+  altitudeMeters?: number | null;
+}): MapPanelCameraState {
+  return {
+    open: true,
+    kind,
+    focusKey: cleanFocusKey(focusKey),
+    coordinates: validCoordinates(longitude, latitude),
+    altitudeMeters:
+      altitudeMeters != null && Number.isFinite(altitudeMeters)
+        ? Math.max(0, altitudeMeters)
+        : null,
+  };
+}
+
+export function panelVisualOffset(
+  delta: { dx: number; dy: number },
+  width: number,
+  height: number,
+): [number, number] {
+  const maxOffset = Math.max(0, Math.min(width, height) * 0.85);
+  return [
+    Math.max(-maxOffset, Math.min(maxOffset, -delta.dx)),
+    Math.max(-maxOffset, Math.min(maxOffset, -delta.dy)),
+  ];
+}
+
+export function shouldCenterMapPanel(
+  previousFocusKey: string | null,
+  state: MapPanelCameraState,
+): boolean {
+  return Boolean(
+    state.open &&
+      state.focusKey &&
+      state.coordinates &&
+      state.focusKey !== previousFocusKey,
+  );
+}
+
+export function coordinatesMatch(
+  first: [number, number] | null,
+  second: [number, number] | null,
+): boolean {
+  if (!first || !second) return false;
+  return (
+    Math.abs(first[0] - second[0]) < 0.000001 &&
+    Math.abs(first[1] - second[1]) < 0.000001
+  );
+}
+
+function cleanFocusKey(value: string | null | undefined): string | null {
+  const cleaned = value?.trim();
+  return cleaned ? cleaned : null;
+}
+
+function validCoordinates(
+  longitude: number | null | undefined,
+  latitude: number | null | undefined,
+): [number, number] | null {
+  const valid =
+    longitude != null &&
+    latitude != null &&
+    Number.isFinite(longitude) &&
+    Number.isFinite(latitude) &&
+    longitude >= -180 &&
+    longitude <= 180 &&
+    latitude >= -90 &&
+    latitude <= 90;
+
+  return valid ? [longitude, latitude] : null;
+}

--- a/src/components/map/use-orbit-camera.ts
+++ b/src/components/map/use-orbit-camera.ts
@@ -18,6 +18,7 @@ export function useOrbitCamera(
   followFlight: FlightState | null | undefined,
   fpvFlight: FlightState | null | undefined,
   settings: Settings,
+  suspended: boolean,
   isInteractingRef: MutableRefObject<boolean>,
   orbitFrameRef: MutableRefObject<number | null>,
   idleTimerRef: MutableRefObject<ReturnType<typeof setTimeout> | null>,
@@ -35,6 +36,7 @@ export function useOrbitCamera(
       !isLoaded ||
       !city ||
       !settings.autoOrbit ||
+      suspended ||
       followFlight ||
       fpvFlight
     ) {
@@ -202,6 +204,7 @@ export function useOrbitCamera(
     followFlight,
     fpvFlight,
     settings.autoOrbit,
+    suspended,
     isInteractingRef,
     orbitFrameRef,
     idleTimerRef,

--- a/src/components/ui/aeris-left-sidebar.tsx
+++ b/src/components/ui/aeris-left-sidebar.tsx
@@ -80,7 +80,7 @@ export function AerisLeftSidebar({
 
   const title =
     panel?.kind === "flight"
-      ? "Flight Details"
+      ? "Aircraft details"
       : panel?.kind === "airport"
         ? "Airport Board"
         : "Aeris";

--- a/src/components/ui/control-panel-settings.tsx
+++ b/src/components/ui/control-panel-settings.tsx
@@ -617,7 +617,7 @@ export const CHANGELOG: {
 }[] = [
   {
     version: "0.8.9",
-    date: "Aug 23, 2026",
+    date: "Aug 24, 2026",
     entries: [
       {
         title: "Open aviation data updates",
@@ -632,7 +632,7 @@ export const CHANGELOG: {
       {
         title: "Simpler aircraft details",
         description:
-          "Reduced the desktop image, moved secondary fields into one Details section, and now hides unsupported aircraft labels.",
+          "Restored the aircraft photo header and flight summary. The sidebar hides unsupported labels. The map keeps selected aircraft centered during panel transitions.",
       },
     ],
   },

--- a/src/components/ui/control-panel-settings.tsx
+++ b/src/components/ui/control-panel-settings.tsx
@@ -610,11 +610,32 @@ function Toggle({ checked }: { checked: boolean }) {
   );
 }
 
-const CHANGELOG: {
+export const CHANGELOG: {
   version: string;
   date: string;
   entries: { title: string; description: string }[];
 }[] = [
+  {
+    version: "0.8.9",
+    date: "Aug 23, 2026",
+    entries: [
+      {
+        title: "Open aviation data updates",
+        description:
+          "Added deterministic refresh and validation commands for open aircraft, registration, and airport data. Scheduled source checks can open a weekly review PR when generated data changes.",
+      },
+      {
+        title: "Aircraft data and route trust",
+        description:
+          "Added aircraft provenance, selected-aircraft fusion, local registry metadata, and position-aware checks for reported routes.",
+      },
+      {
+        title: "Simpler aircraft details",
+        description:
+          "Reduced the desktop image, moved secondary fields into one Details section, and now hides unsupported aircraft labels.",
+      },
+    ],
+  },
   {
     version: "0.8.8",
     date: "Aug 23, 2026",

--- a/src/components/ui/flight-card.test.ts
+++ b/src/components/ui/flight-card.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { RouteSummary } from "./flight-card";
+import type { FlightRouteInfo } from "@/hooks/use-route-info";
+
+const VALID_ROUTE: FlightRouteInfo = {
+  origin: {
+    iata: "SFO",
+    icao: "KSFO",
+    name: "San Francisco International Airport",
+    municipality: "San Francisco",
+    countryIso: "US",
+    latitude: 37.6213,
+    longitude: -122.379,
+  },
+  destination: {
+    iata: "JFK",
+    icao: "KJFK",
+    name: "John F. Kennedy International Airport",
+    municipality: "New York",
+    countryIso: "US",
+    latitude: 40.6413,
+    longitude: -73.7781,
+  },
+  loading: false,
+  available: true,
+  unavailable: false,
+  routeDisplay: "SFO to JFK",
+  source: "adsbdb",
+  sources: ["adsbdb"],
+  validatedAt: 1_800_000_000_000,
+};
+
+test("RouteSummary labels a valid result as a reported route", () => {
+  const html = renderToStaticMarkup(
+    createElement(RouteSummary, { routeInfo: VALID_ROUTE }),
+  );
+
+  assert.match(html, /Reported route/);
+  assert.match(html, /SFO/);
+  assert.match(html, /JFK/);
+  assert.doesNotMatch(html, /verified/i);
+  assert.doesNotMatch(html, />-</);
+});
+
+test("RouteSummary hides unavailable and incomplete results", () => {
+  const unavailable = renderToStaticMarkup(
+    createElement(RouteSummary, {
+      routeInfo: { ...VALID_ROUTE, available: false },
+    }),
+  );
+  const incomplete = renderToStaticMarkup(
+    createElement(RouteSummary, {
+      routeInfo: { ...VALID_ROUTE, destination: null },
+    }),
+  );
+
+  assert.equal(unavailable, "");
+  assert.equal(incomplete, "");
+});

--- a/src/components/ui/flight-card.tsx
+++ b/src/components/ui/flight-card.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Image from "next/image";
 import { AnimatePresence, motion } from "motion/react";
 import { ChevronDown, Eye, Plane, X } from "lucide-react";
 import { useAircraftPhotos } from "@/hooks/use-aircraft-photos";
@@ -28,6 +27,9 @@ import {
   formatAircraftDataSources,
   formatAircraftFreshness,
 } from "@/lib/aircraft-sidebar";
+import { AirlineLogo } from "@/components/ui/airline-logo";
+import { PositionSourceBadge } from "@/components/ui/flight-badges";
+import { HeroBanner } from "@/components/ui/hero-banner";
 import { cn } from "@/lib/utils";
 
 type FlightCardProps = {
@@ -50,10 +52,11 @@ export function FlightCard({
   const { settings } = useSettings();
   const routeInfo = useRouteInfo(flight);
   const airline = flight ? lookupAirline(flight.callsign) : null;
-  const { photos, aircraft: photoAircraft } = useAircraftPhotos(
-    flight?.icao24 ?? null,
-    flight?.registration,
-  );
+  const {
+    photos,
+    aircraft: photoAircraft,
+    loading: photosLoading,
+  } = useAircraftPhotos(flight?.icao24 ?? null, flight?.registration);
 
   return (
     <AnimatePresence mode="wait">
@@ -77,6 +80,7 @@ export function FlightCard({
             airline={airline}
             photoAircraft={photoAircraft}
             heroPhoto={photos[0] ?? null}
+            photosLoading={photosLoading}
             routeInfo={routeInfo}
             unitSystem={settings.unitSystem}
             showDebugData={settings.showDebugData}
@@ -96,6 +100,7 @@ type FlightCardContentProps = {
   airline: string | null;
   photoAircraft: AircraftDetails | null;
   heroPhoto: NormalizedPhoto | null;
+  photosLoading: boolean;
   routeInfo: FlightRouteInfo;
   unitSystem: UnitSystem;
   showDebugData: boolean;
@@ -110,6 +115,7 @@ function FlightCardContent({
   airline,
   photoAircraft,
   heroPhoto,
+  photosLoading,
   routeInfo,
   unitSystem,
   showDebugData,
@@ -150,6 +156,27 @@ function FlightCardContent({
       ? flight.emergencyStatus
       : null,
   ].filter((value): value is string => Boolean(value));
+  const primaryFields = [
+    hasPosition(flight)
+      ? {
+          label: "Position",
+          value: formatPosition(flight.latitude, flight.longitude),
+        }
+      : null,
+    finiteValue(flight.baroAltitude) !== null
+      ? {
+          label: "Altitude",
+          value: formatAltitude(flight.baroAltitude, unitSystem),
+        }
+      : null,
+    finiteValue(flight.velocity) !== null
+      ? {
+          label: "Speed",
+          value: formatSpeed(flight.velocity, unitSystem),
+        }
+      : null,
+    { label: "Status", value: statusItems.join(", ") },
+  ].filter((field): field is { label: string; value: string } => field !== null);
 
   return (
     <div
@@ -160,34 +187,54 @@ function FlightCardContent({
           : "rounded-2xl border border-foreground/10 bg-background/90 shadow-2xl backdrop-blur-xl",
       )}
     >
-      <div className="px-5 pb-5 pt-2">
-        <div className="flex items-start gap-3 border-b border-foreground/10 pb-4">
-          <div className="flex min-w-0 flex-1 gap-3">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center text-foreground/55">
-              <Plane className="h-6 w-6" aria-hidden="true" />
-            </div>
-            <div className="min-w-0 pt-0.5">
-              <h3 className="truncate text-lg font-semibold tracking-tight">
-                {identity}
-              </h3>
-              <p className="mt-0.5 font-mono text-[11px] uppercase tracking-wider text-foreground/50">
-                ICAO {flight.icao24}
-                {flightNumber ? `, flight ${flightNumber}` : ""}
-              </p>
-              {details.airline && (
-                <p className="mt-1 truncate text-xs text-foreground/70">
-                  Airline: {details.airline}
-                </p>
-              )}
-            </div>
+      <HeroBanner
+        photo={heroPhoto}
+        loading={photosLoading}
+        alt={`${identity} aircraft`}
+      />
+
+      <div className="px-5 pb-5 pt-4">
+        <div className="flex items-center gap-3.5">
+          <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-[20px] border border-foreground/[0.08] bg-foreground/[0.055] shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+            {airline ? (
+              <span className="flex h-14 w-14 items-center justify-center overflow-hidden rounded-[16px] border border-black/5 bg-white/95 shadow-sm">
+                <AirlineLogo
+                  callsign={flight.callsign}
+                  airlineName={airline}
+                  size={40}
+                  className="rounded-none bg-transparent"
+                />
+              </span>
+            ) : (
+              <Plane
+                className="h-7 w-7 text-foreground/45"
+                aria-hidden="true"
+              />
+            )}
           </div>
 
-          {heroPhoto && (
-            <PhotoPreview
-              photo={heroPhoto}
-              label={details.registration ?? identity}
-            />
-          )}
+          <div className="min-w-0 flex-1">
+            <div className="flex min-w-0 items-center gap-1.5">
+              <h3 className="truncate text-[19px] font-semibold leading-tight tracking-tight">
+                {identity}
+              </h3>
+              <PositionSourceBadge source={flight.positionSource} />
+            </div>
+            <p className="mt-1 flex min-w-0 items-center gap-1.5 font-mono text-[11px] font-medium uppercase tracking-wide text-foreground/45">
+              <span className="truncate">ICAO {flight.icao24}</span>
+              {flightNumber && (
+                <>
+                  <span aria-hidden="true">·</span>
+                  <span className="shrink-0">Flight {flightNumber}</span>
+                </>
+              )}
+            </p>
+            {details.airline && (
+              <p className="mt-1 truncate text-[12px] text-foreground/62">
+                {details.airline}
+              </p>
+            )}
+          </div>
 
           {!isSidebar && (
             <button
@@ -203,29 +250,19 @@ function FlightCardContent({
 
         <RouteSummary routeInfo={routeInfo} />
 
-        <dl className="grid grid-cols-2 border-b border-foreground/10 py-3">
-          {hasPosition(flight) && (
+        <dl className="mt-3 grid grid-cols-2 overflow-hidden rounded-[14px] border border-foreground/[0.07] bg-foreground/[0.035]">
+          {primaryFields.map((field, index) => (
             <PrimaryField
-              label="Position"
-              value={formatPosition(flight.latitude, flight.longitude)}
+              key={field.label}
+              label={field.label}
+              value={field.value}
+              dividedTop={index >= 2}
+              dividedRight={index % 2 === 0 && index < primaryFields.length - 1}
             />
-          )}
-          {finiteValue(flight.baroAltitude) !== null && (
-            <PrimaryField
-              label="Altitude"
-              value={formatAltitude(flight.baroAltitude, unitSystem)}
-            />
-          )}
-          {finiteValue(flight.velocity) !== null && (
-            <PrimaryField
-              label="Speed"
-              value={formatSpeed(flight.velocity, unitSystem)}
-            />
-          )}
-          <PrimaryField label="Status" value={statusItems.join(", ")} />
+          ))}
         </dl>
 
-        <div className="border-b border-foreground/10 py-3 text-xs text-foreground/65">
+        <div className="border-b border-foreground/10 px-0.5 py-3 text-xs text-foreground/65">
           <p aria-live="off" aria-atomic="false">
             {freshness}
           </p>
@@ -335,43 +372,7 @@ function FlightCardContent({
   );
 }
 
-function PhotoPreview({
-  photo,
-  label,
-}: {
-  photo: NormalizedPhoto;
-  label: string;
-}) {
-  const image = (
-    <Image
-      src={photo.thumbnail || photo.url}
-      alt={`${label} aircraft`}
-      width={112}
-      height={80}
-      className="h-20 w-28 object-cover"
-      unoptimized
-    />
-  );
-
-  return (
-    <figure className="w-28 shrink-0 overflow-hidden rounded-lg">
-      {photo.link ? (
-        <a href={photo.link} target="_blank" rel="noreferrer">
-          {image}
-        </a>
-      ) : (
-        image
-      )}
-      {photo.photographer && (
-        <figcaption className="truncate pt-1 text-[9px] text-foreground/45">
-          Photo: {photo.photographer}
-        </figcaption>
-      )}
-    </figure>
-  );
-}
-
-function RouteSummary({ routeInfo }: { routeInfo: FlightRouteInfo }) {
+export function RouteSummary({ routeInfo }: { routeInfo: FlightRouteInfo }) {
   if (!routeInfo.available) return null;
 
   const origin = routeInfo.origin ? formatAirportCode(routeInfo.origin) : null;
@@ -382,28 +383,72 @@ function RouteSummary({ routeInfo }: { routeInfo: FlightRouteInfo }) {
   if (!origin || !destination) return null;
 
   return (
-    <section className="border-b border-foreground/10 py-3">
+    <section className="mt-4 rounded-[14px] border border-foreground/[0.07] bg-foreground/[0.035] px-4 py-3.5">
       <p className="text-[10px] font-semibold uppercase tracking-wider text-foreground/45">
         Reported route
       </p>
-      <p className="mt-1 text-base font-semibold tracking-tight">
-        {origin} <span aria-hidden="true">→</span> {destination}
-      </p>
-      {(routeInfo.origin?.municipality ||
-        routeInfo.destination?.municipality) && (
-        <p className="mt-1 truncate text-xs text-foreground/55">
-          {[routeInfo.origin?.municipality, routeInfo.destination?.municipality]
-            .filter(Boolean)
-            .join(" to ")}
-        </p>
-      )}
+      <div className="mt-2 flex items-center gap-3">
+        <RouteEndpoint
+          code={origin}
+          municipality={routeInfo.origin?.municipality}
+        />
+        <div className="flex shrink-0 items-center gap-1.5 text-foreground/38">
+          <span className="h-px w-4 bg-foreground/12" aria-hidden="true" />
+          <Plane className="h-3.5 w-3.5" aria-hidden="true" />
+          <span className="h-px w-4 bg-foreground/12" aria-hidden="true" />
+        </div>
+        <RouteEndpoint
+          code={destination}
+          municipality={routeInfo.destination?.municipality}
+          align="right"
+        />
+      </div>
     </section>
   );
 }
 
-function PrimaryField({ label, value }: { label: string; value: string }) {
+function RouteEndpoint({
+  code,
+  municipality,
+  align = "left",
+}: {
+  code: string;
+  municipality?: string | null;
+  align?: "left" | "right";
+}) {
   return (
-    <div className="min-w-0 py-2 pr-3">
+    <div className={cn("min-w-0 flex-1", align === "right" && "text-right")}>
+      <p className="text-[17px] font-semibold tracking-tight text-foreground/92">
+        {code}
+      </p>
+      {municipality && (
+        <p className="mt-0.5 truncate text-[11px] font-medium text-foreground/45">
+          {municipality}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function PrimaryField({
+  label,
+  value,
+  dividedTop,
+  dividedRight,
+}: {
+  label: string;
+  value: string;
+  dividedTop: boolean;
+  dividedRight: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "min-h-[70px] min-w-0 px-3.5 py-3",
+        dividedTop && "border-t border-foreground/[0.06]",
+        dividedRight && "border-r border-foreground/[0.06]",
+      )}
+    >
       <dt className="text-[10px] font-semibold uppercase tracking-wider text-foreground/45">
         {label}
       </dt>

--- a/src/components/ui/flight-card.tsx
+++ b/src/components/ui/flight-card.tsx
@@ -1,61 +1,33 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
-import { motion, AnimatePresence } from "motion/react";
-import {
-  ArrowUp,
-  ArrowDown,
-  Gauge,
-  Compass,
-  Globe,
-  X,
-  Navigation,
-  Building2,
-  Eye,
-  ChevronRight,
-  ChevronDown,
-  Plane,
-  TrendingUp,
-} from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
+import { ChevronDown, Eye, Plane, X } from "lucide-react";
 import { useAircraftPhotos } from "@/hooks/use-aircraft-photos";
-import { AircraftPhotos } from "@/components/ui/aircraft-photos";
-import { HeroBanner } from "@/components/ui/hero-banner";
-import {
-  OnGroundBadge,
-  AircraftOperatorLine,
-  AircraftTypeLine,
-  PositionSourceBadge,
-} from "@/components/ui/flight-badges";
+import type {
+  AircraftDetails,
+  NormalizedPhoto,
+} from "@/hooks/use-aircraft-photos";
 import type { FlightState, FlightTrack } from "@/lib/opensky";
-import { VerticalProfile } from "@/components/ui/vertical-profile";
 import type { TrailEntry } from "@/hooks/use-trail-history";
-import { useSettings } from "@/hooks/use-settings";
-import {
-  formatCallsign,
-  headingToCardinal,
-} from "@/lib/flight-utils";
+import { useSettings, type UnitSystem } from "@/hooks/use-settings";
+import { headingToCardinal } from "@/lib/flight-utils";
 import { lookupAirline, parseFlightNumber } from "@/lib/airlines";
-import { aircraftTypeHint } from "@/lib/aircraft";
-import { airlineLogoCandidates } from "@/lib/airline-logos";
-import {
-  loadedAirlineLogoUrls,
-  trackAirlineLogoLoaded,
-  markAirlineLogoFailed,
-  wasAirlineLogoRecentlyFailed,
-} from "@/lib/logo-cache";
 import type { FlightRouteInfo } from "@/hooks/use-route-info";
 import { useRouteInfo } from "@/hooks/use-route-info";
 import { formatAirportCode } from "@/lib/route-lookup";
-import { AvionicsSection } from "@/components/ui/avionics-section";
-import { DebugDataSection } from "@/components/ui/debug-data-section";
-import { FlightWeatherSection } from "@/components/ui/flight-weather-section";
 import {
   formatAltitude,
   formatSpeed,
   formatSpeedFromKnots,
   formatVerticalSpeed,
 } from "@/lib/unit-formatters";
+import {
+  buildAircraftSidebarViewModel,
+  formatAircraftDataSources,
+  formatAircraftFreshness,
+} from "@/lib/aircraft-sidebar";
 import { cn } from "@/lib/utils";
 
 type FlightCardProps = {
@@ -70,7 +42,6 @@ type FlightCardProps = {
 
 export function FlightCard({
   flight,
-  trail,
   onClose,
   onToggleFpv,
   isFpvActive = false,
@@ -79,73 +50,9 @@ export function FlightCard({
   const { settings } = useSettings();
   const routeInfo = useRouteInfo(flight);
   const airline = flight ? lookupAirline(flight.callsign) : null;
-  const flightNum = flight ? parseFlightNumber(flight.callsign) : null;
-  const company =
-    airline ??
-    (flight?.registrationCountry
-      ? `${flight.registrationCountry} operator`
-      : null);
-  const model = flight ? aircraftTypeHint(flight.category) : null;
-  const logoCandidates = airlineLogoCandidates(airline, flight?.callsign);
-  const heading = flight?.trueTrack ?? null;
-  const cardinal = heading !== null ? headingToCardinal(heading) : null;
-  const canEnterFpv =
-    flight != null &&
-    flight.longitude != null &&
-    flight.latitude != null &&
-    !flight.onGround;
-  const [logoIndexByAirline, setLogoIndexByAirline] = useState<
-    Record<string, number>
-  >({});
-  const [logoLoadedByKey, setLogoLoadedByKey] = useState<
-    Record<string, boolean>
-  >({});
-  const [genericLogoFailed, setGenericLogoFailed] = useState(false);
-  const airlineKey = airline ?? "__none__";
-  const baseLogoIndex = logoIndexByAirline[airlineKey] ?? 0;
-  const resolvedLogoIndex = useMemo(() => {
-    let idx = baseLogoIndex;
-    while (
-      idx < logoCandidates.length &&
-      wasAirlineLogoRecentlyFailed(logoCandidates[idx] ?? "")
-    ) {
-      idx += 1;
-    }
-    return idx;
-  }, [baseLogoIndex, logoCandidates]);
-
-  const logoLoadKey = `${airlineKey}:${resolvedLogoIndex}`;
-  const logoUrl = logoCandidates[resolvedLogoIndex] ?? null;
-  const logoLoaded =
-    (logoUrl ? loadedAirlineLogoUrls.has(logoUrl) : false) ||
-    (logoLoadedByKey[logoLoadKey] ?? false);
-  const showLogo = Boolean(logoUrl);
-  const genericLogoUrl = "/airline-logos/envoy-air.png";
-
-  const {
-    photos,
-    aircraft: photoAircraft,
-    loading: photosLoading,
-    error: photosError,
-  } = useAircraftPhotos(flight?.icao24 ?? null, flight?.registration);
-  const heroPhoto = photos[0] ?? null;
-  const [vpOpen, setVpOpen] = useState(false);
-  const isSidebar = variant === "sidebar";
-  const verticalRate =
-    flight?.verticalRate != null && Number.isFinite(flight.verticalRate)
-      ? flight.verticalRate
-      : flight?.geomRate != null && Number.isFinite(flight.geomRate)
-        ? flight.geomRate
-        : null;
-  const showDebugData =
-    settings.showDebugData && hasDebugData(flight?.debugData);
-  const hasAircraftMetadata = Boolean(
-    flight?.typeCode ||
-      flight?.typeDescription ||
-      model ||
-      flight?.registration ||
-      photoAircraft?.manufacturer ||
-      photoAircraft?.owner,
+  const { photos, aircraft: photoAircraft } = useAircraftPhotos(
+    flight?.icao24 ?? null,
+    flight?.registration,
   );
 
   return (
@@ -153,458 +60,432 @@ export function FlightCard({
       {flight && (
         <motion.div
           key={flight.icao24}
-          initial={{ opacity: 0, x: -16, scale: 0.96 }}
-          animate={{ opacity: 1, x: 0, scale: 1 }}
-          exit={{ opacity: 0, x: -16, scale: 0.96 }}
-          transition={{
-            type: "spring",
-            stiffness: 400,
-            damping: 28,
-            mass: 0.8,
-          }}
+          initial={{ opacity: 0, x: -12 }}
+          animate={{ opacity: 1, x: 0 }}
+          exit={{ opacity: 0, x: -12 }}
+          transition={{ duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
           className={
-            isSidebar
+            variant === "sidebar"
               ? "h-full w-full"
-              : "w-[22rem] max-w-[calc(100vw-1rem)] sm:w-[23rem]"
+              : "w-[22rem] max-w-[calc(100vw-1rem)]"
           }
           role="complementary"
-          aria-label="Selected flight details"
-          aria-live="polite"
+          aria-label="Selected aircraft details"
         >
-          <div
-            className={cn(
-              "overflow-hidden text-foreground",
-              isSidebar
-                ? "h-full overflow-y-auto overscroll-contain bg-sidebar/80 [scrollbar-width:thin] supports-[backdrop-filter]:bg-sidebar/70"
-                : "rounded-[28px] border border-foreground/[0.08] bg-background/80 shadow-[0_24px_70px_rgba(0,0,0,0.42)] backdrop-blur-2xl supports-[backdrop-filter]:bg-background/70",
-            )}
-          >
-            <HeroBanner
-              photo={heroPhoto}
-              loading={photosLoading}
-            />
-
-            <div className={isSidebar ? "px-5 pb-7 pt-4" : "p-4"}>
-              <div className="flex items-center gap-3.5">
-                <div className="relative flex h-16 w-16 shrink-0 items-center justify-center rounded-[20px] border border-foreground/[0.08] bg-foreground/[0.055] shadow-[inset_0_1px_0_rgba(255,255,255,0.06),0_10px_26px_rgba(0,0,0,0.18)]">
-                  {showLogo ? (
-                    <span className="relative flex h-14 w-14 items-center justify-center overflow-hidden rounded-[16px] border border-black/5 bg-white/95 p-3 shadow-sm">
-                      {!logoLoaded && (
-                        <span
-                          aria-hidden="true"
-                          className="absolute inset-0 animate-pulse bg-linear-to-br from-white/85 via-neutral-200/65 to-white/80"
-                        />
-                      )}
-                      <Image
-                        src={logoUrl ?? undefined}
-                        alt={company ? `${company} logo` : "Airline logo"}
-                        width={68}
-                        height={68}
-                        className={`relative h-11 w-11 object-contain transition-opacity duration-200 ${
-                          logoLoaded ? "opacity-100" : "opacity-0"
-                        }`}
-                        unoptimized
-                        onLoad={() => {
-                          if (logoUrl) trackAirlineLogoLoaded(logoUrl);
-                          setLogoLoadedByKey((current) => ({
-                            ...current,
-                            [logoLoadKey]: true,
-                          }));
-                        }}
-                        onError={() => {
-                          if (logoUrl) markAirlineLogoFailed(logoUrl);
-                          if (resolvedLogoIndex + 1 < logoCandidates.length) {
-                            setLogoIndexByAirline((current) => ({
-                              ...current,
-                              [airlineKey]: resolvedLogoIndex + 1,
-                            }));
-                            return;
-                          }
-                          setLogoIndexByAirline((current) => ({
-                            ...current,
-                            [airlineKey]: logoCandidates.length,
-                          }));
-                        }}
-                      />
-                    </span>
-                  ) : (
-                    <span className="relative flex h-14 w-14 items-center justify-center overflow-hidden rounded-[16px] border border-black/5 bg-white/95 p-3 shadow-sm">
-                      {genericLogoFailed ? (
-                        <span className="text-[22px] font-semibold text-background/25">
-                          -
-                        </span>
-                      ) : (
-                        <Image
-                          src={genericLogoUrl}
-                          alt="Generic airline logo"
-                          width={68}
-                          height={68}
-                          className="h-11 w-11 object-contain grayscale opacity-80"
-                          unoptimized
-                          onError={() => setGenericLogoFailed(true)}
-                        />
-                      )}
-                    </span>
-                  )}
-                </div>
-                <div className="min-w-0 flex-1">
-                  <div className="flex min-w-0 items-center gap-1.5">
-                    <p className="truncate text-[19px] font-semibold leading-tight tracking-tight text-foreground">
-                      {formatCallsign(flight.callsign)}
-                    </p>
-                    <PositionSourceBadge source={flight.positionSource} />
-                    <OnGroundBadge onGround={flight.onGround} />
-                  </div>
-                  <p className="mt-1 truncate text-[11px] font-medium tracking-wide text-foreground/42 uppercase">
-                    {flight.icao24}
-                    {flightNum ? ` · #${flightNum}` : ""}
-                  </p>
-                </div>
-              </div>
-
-              {(company || hasAircraftMetadata) && (
-                <div className="mt-4 overflow-hidden rounded-[22px] border border-foreground/[0.07] bg-foreground/[0.035] shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]">
-                  {company && (
-                    <GroupedRow icon={<Building2 className="h-3.5 w-3.5" />}>
-                      <p className="min-w-0 truncate text-[13px] font-medium text-foreground/78">
-                        {company}
-                      </p>
-                    </GroupedRow>
-                  )}
-
-                  {hasAircraftMetadata && (
-                    <GroupedRow
-                      icon={<Plane className="h-3.5 w-3.5" />}
-                      divided={Boolean(company)}
-                    >
-                      <div className="min-w-0 space-y-0.5">
-                        <AircraftTypeLine
-                          typeCode={flight.typeCode}
-                          typeDescription={flight.typeDescription ?? model}
-                          registration={flight.registration}
-                        />
-                        <AircraftOperatorLine
-                          manufacturer={photoAircraft?.manufacturer}
-                          owner={photoAircraft?.owner}
-                          airlineName={company}
-                        />
-                      </div>
-                    </GroupedRow>
-                  )}
-                </div>
-              )}
-
-              {/* Military / Emergency indicators */}
-              {(isMilitary(flight.dbFlags) ||
-                isEmergencyStatus(flight.emergencyStatus)) && (
-                <div className="mt-3 flex flex-wrap items-center gap-2">
-                  {isMilitary(flight.dbFlags) && (
-                    <span className="inline-flex items-center gap-1.5 rounded-full border border-amber-400/20 bg-amber-400/10 px-2.5 py-1 text-[11px] font-medium tracking-wide text-amber-300/85">
-                      <span className="h-1.5 w-1.5 rounded-full bg-amber-300/80" />
-                      Military
-                    </span>
-                  )}
-                  {isEmergencyStatus(flight.emergencyStatus) && (
-                    <span className="inline-flex items-center gap-1.5 rounded-full border border-red-400/25 bg-red-500/10 px-2.5 py-1 text-[11px] font-medium tracking-wide text-red-300/90">
-                      <span className="h-1.5 w-1.5 rounded-full bg-red-400" />
-                      {flight.emergencyStatus}
-                    </span>
-                  )}
-                </div>
-              )}
-
-              <RouteBanner
-                routeInfo={routeInfo}
-                showSource={settings.showDebugData}
-              />
-
-              {routeInfo.available &&
-                (routeInfo.origin?.icao || routeInfo.destination?.icao) && (
-                  <div className="mt-3">
-                    <FlightWeatherSection
-                      routeInfo={routeInfo}
-                      unitSystem={settings.unitSystem}
-                    />
-                  </div>
-                )}
-
-              <div className="mt-4 grid grid-cols-2 gap-2 rounded-[24px] border border-foreground/[0.07] bg-foreground/[0.035] p-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]">
-                <Metric
-                  icon={<ArrowUp className="h-3 w-3" />}
-                  label="Altitude"
-                  value={formatAltitude(
-                    flight.baroAltitude,
-                    settings.unitSystem,
-                  )}
-                  secondary={
-                    flight.geoAltitude !== null
-                      ? `GPS ${formatAltitude(
-                          flight.geoAltitude,
-                          settings.unitSystem,
-                        )}`
-                      : null
-                  }
-                />
-                <Metric
-                  icon={<Gauge className="h-3 w-3" />}
-                  label="Speed"
-                  value={formatSpeed(flight.velocity, settings.unitSystem)}
-                  secondary={
-                    flight.tas != null && Number.isFinite(flight.tas)
-                      ? `TAS ${formatSpeedFromKnots(
-                          flight.tas,
-                          settings.unitSystem,
-                        )}`
-                      : null
-                  }
-                />
-                <Metric
-                  icon={<Compass className="h-3 w-3" />}
-                  label="Heading"
-                  value={
-                    heading !== null && Number.isFinite(heading)
-                      ? `${Math.round(heading)}° ${cardinal}`
-                      : "-"
-                  }
-                />
-                <Metric
-                  icon={<ArrowDown className="h-3 w-3" />}
-                  label="V/S"
-                  value={formatVerticalSpeed(
-                    verticalRate,
-                    settings.unitSystem,
-                  )}
-                />
-              </div>
-
-              <div className="mt-3">
-                <AvionicsSection
-                  flight={flight}
-                  unitSystem={settings.unitSystem}
-                />
-              </div>
-
-              <div className="mt-4 overflow-hidden rounded-[22px] border border-foreground/[0.07] bg-foreground/[0.035] shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]">
-                <GroupedRow icon={<Globe className="h-3.5 w-3.5" />}>
-                  <p className="text-[13px] text-foreground/65">
-                    {flight.registrationCountry}
-                  </p>
-                </GroupedRow>
-                {cardinal && (
-                  <GroupedRow
-                    icon={
-                      <Navigation
-                        className="h-3.5 w-3.5"
-                        style={{
-                          transform:
-                            heading !== null && Number.isFinite(heading)
-                              ? `rotate(${heading}deg)`
-                              : undefined,
-                        }}
-                      />
-                    }
-                    divided
-                  >
-                    <p className="text-[13px] text-foreground/65">
-                      Heading {cardinal}
-                      {flight.latitude !== null &&
-                        flight.longitude !== null &&
-                        Number.isFinite(flight.latitude) &&
-                        Number.isFinite(flight.longitude) && (
-                          <span className="text-foreground/35">
-                            {" "}
-                            · {Math.abs(flight.latitude).toFixed(2)}°
-                            {flight.latitude >= 0 ? "N" : "S"},{" "}
-                            {Math.abs(flight.longitude).toFixed(2)}°
-                            {flight.longitude >= 0 ? "E" : "W"}
-                          </span>
-                        )}
-                    </p>
-                  </GroupedRow>
-                )}
-                {flight.squawk && (
-                  <GroupedRow
-                    icon={
-                      <span
-                        className={`text-[9px] font-bold leading-none ${
-                          isEmergencySquawk(flight.squawk)
-                            ? "text-red-300"
-                            : "text-foreground/45"
-                        }`}
-                      >
-                        SQ
-                      </span>
-                    }
-                    divided
-                  >
-                    <p
-                      className={`font-mono text-[13px] tabular-nums ${
-                        isEmergencySquawk(flight.squawk)
-                          ? "text-red-300"
-                          : "text-foreground/65"
-                      }`}
-                    >
-                      {flight.squawk}
-                      {isEmergencySquawk(flight.squawk) && (
-                        <span className="ml-2 font-sans text-[11px] font-medium tracking-wide text-red-300/85">
-                          {squawkLabel(flight.squawk)}
-                        </span>
-                      )}
-                    </p>
-                  </GroupedRow>
-                )}
-              </div>
-
-              {showDebugData && (
-                <div className="mt-4 overflow-hidden rounded-[22px] border border-foreground/[0.07] bg-foreground/[0.035] p-3.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]">
-                  <DebugDataSection data={flight.debugData} />
-                </div>
-              )}
-
-              {onToggleFpv && (
-                <div className="mt-4 overflow-hidden rounded-[22px] border border-foreground/[0.07] bg-foreground/[0.035] shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]">
-                  <button
-                    type="button"
-                    onClick={() =>
-                      (isFpvActive || canEnterFpv) &&
-                      flight &&
-                      onToggleFpv(flight.icao24)
-                    }
-                    disabled={!isFpvActive && !canEnterFpv}
-                    className={`flex min-h-11 w-full items-center gap-3 px-3.5 py-2.5 text-left transition-colors hover:bg-foreground/[0.04] active:bg-foreground/[0.07] ${
-                      !isFpvActive && !canEnterFpv
-                        ? "cursor-not-allowed opacity-35"
-                        : ""
-                    }`}
-                    aria-label={
-                      isFpvActive
-                        ? "Exit first person view"
-                        : canEnterFpv
-                          ? "First person view"
-                          : "First person view unavailable"
-                    }
-                    title={
-                      isFpvActive
-                        ? "Exit FPV (F)"
-                        : canEnterFpv
-                          ? "First Person View (F)"
-                          : flight?.onGround
-                            ? "FPV unavailable (aircraft on ground)"
-                            : "FPV unavailable (no position data)"
-                    }
-                  >
-                    <IconCell active={isFpvActive}>
-                      <Eye
-                        className={`h-3.5 w-3.5 ${isFpvActive ? "text-emerald-300" : ""}`}
-                      />
-                    </IconCell>
-                    <span
-                      className={`min-w-0 flex-1 text-[13px] font-medium ${isFpvActive ? "text-emerald-300/90" : "text-foreground/72"}`}
-                    >
-                      {isFpvActive
-                        ? "Exit First Person View"
-                        : "First Person View"}
-                    </span>
-                    <ChevronRight
-                      className={`h-4 w-4 shrink-0 ${isFpvActive ? "text-emerald-300/45" : "text-foreground/24"}`}
-                    />
-                  </button>
-                </div>
-              )}
-
-              <AircraftPhotos
-                photos={photos}
-                loading={photosLoading}
-                aircraft={photoAircraft}
-                error={photosError}
-              />
-
-              {trail && trail.path.length >= 3 && (
-                <div className="mt-4 overflow-hidden rounded-[22px] border border-foreground/[0.07] bg-foreground/[0.035] shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]">
-                  <button
-                    type="button"
-                    onClick={() => setVpOpen((o) => !o)}
-                    className="flex min-h-11 w-full items-center gap-3 px-3.5 py-2.5 text-left transition-colors hover:bg-foreground/[0.04] active:bg-foreground/[0.07]"
-                    aria-expanded={vpOpen}
-                    aria-label={
-                      vpOpen
-                        ? "Collapse vertical profile"
-                        : "Expand vertical profile"
-                    }
-                  >
-                    <IconCell>
-                      <TrendingUp className="h-3.5 w-3.5" />
-                    </IconCell>
-                    <span className="min-w-0 flex-1 text-[13px] font-medium text-foreground/72">
-                      Vertical Profile
-                    </span>
-                    <ChevronDown
-                      className={`h-4 w-4 shrink-0 text-foreground/24 transition-transform duration-200 ${vpOpen ? "rotate-180" : ""}`}
-                    />
-                  </button>
-                  <AnimatePresence initial={false}>
-                    {vpOpen && (
-                      <motion.div
-                        key="vp"
-                        initial={{ height: 0, opacity: 0 }}
-                        animate={{ height: "auto", opacity: 1 }}
-                        exit={{ height: 0, opacity: 0 }}
-                        transition={{ duration: 0.2, ease: "easeInOut" }}
-                        className="overflow-hidden border-t border-foreground/[0.06]"
-                      >
-                        <div className="px-3 pb-3 pt-2">
-                          <VerticalProfile
-                            trail={trail}
-                            navAltitudeMcp={flight.navAltitudeMcp}
-                          />
-                        </div>
-                      </motion.div>
-                    )}
-                  </AnimatePresence>
-                </div>
-              )}
-
-              <div className="mt-4 overflow-hidden rounded-[22px] border border-foreground/[0.07] bg-foreground/[0.035] shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]">
-                <button
-                  type="button"
-                  onClick={onClose}
-                  className="flex min-h-11 w-full items-center gap-3 px-3.5 py-2.5 text-left transition-colors hover:bg-foreground/[0.04] active:bg-foreground/[0.07]"
-                  aria-label="Deselect flight"
-                >
-                  <IconCell>
-                    <X className="h-3.5 w-3.5" />
-                  </IconCell>
-                  <span className="min-w-0 flex-1 text-[13px] font-medium text-foreground/72">
-                    Close
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
+          <FlightCardContent
+            flight={flight}
+            airline={airline}
+            photoAircraft={photoAircraft}
+            heroPhoto={photos[0] ?? null}
+            routeInfo={routeInfo}
+            unitSystem={settings.unitSystem}
+            showDebugData={settings.showDebugData}
+            onClose={onClose}
+            onToggleFpv={onToggleFpv}
+            isFpvActive={isFpvActive}
+            isSidebar={variant === "sidebar"}
+          />
         </motion.div>
       )}
     </AnimatePresence>
   );
 }
 
-const EMERGENCY_SQUAWKS = new Set(["7500", "7600", "7700"]);
+type FlightCardContentProps = {
+  flight: FlightState;
+  airline: string | null;
+  photoAircraft: AircraftDetails | null;
+  heroPhoto: NormalizedPhoto | null;
+  routeInfo: FlightRouteInfo;
+  unitSystem: UnitSystem;
+  showDebugData: boolean;
+  onClose: () => void;
+  onToggleFpv?: (icao24: string) => void;
+  isFpvActive: boolean;
+  isSidebar: boolean;
+};
 
-function isEmergencySquawk(squawk: string | null): boolean {
-  if (!squawk) return false;
-  return EMERGENCY_SQUAWKS.has(squawk.trim());
+function FlightCardContent({
+  flight,
+  airline,
+  photoAircraft,
+  heroPhoto,
+  routeInfo,
+  unitSystem,
+  showDebugData,
+  onClose,
+  onToggleFpv,
+  isFpvActive,
+  isSidebar,
+}: FlightCardContentProps) {
+  const details = buildAircraftSidebarViewModel(
+    flight,
+    airline,
+    photoAircraft,
+  );
+  const updatedAt =
+    flight.provenance.observationTime ?? flight.provenance.responseTime;
+  const freshness = useFreshness(updatedAt);
+  const sources = formatAircraftDataSources(
+    flight.provenance.contributingSources,
+  );
+  const flightNumber = details.airline
+    ? parseFlightNumber(flight.callsign)
+    : null;
+  const heading = flight.trueTrack;
+  const cardinal = heading !== null ? headingToCardinal(heading) : null;
+  const verticalRate = finiteValue(flight.verticalRate ?? flight.geomRate);
+  const canEnterFpv =
+    flight.longitude !== null &&
+    flight.latitude !== null &&
+    !flight.onGround;
+  const identity =
+    cleanText(flight.callsign) ??
+    details.registration ??
+    flight.icao24.toUpperCase();
+  const statusItems = [
+    flight.onGround ? "On ground" : "Airborne",
+    isMilitary(flight.dbFlags) ? "Military" : null,
+    isEmergencyStatus(flight.emergencyStatus)
+      ? flight.emergencyStatus
+      : null,
+  ].filter((value): value is string => Boolean(value));
+
+  return (
+    <div
+      className={cn(
+        "h-full overflow-y-auto overscroll-contain text-foreground [scrollbar-width:thin]",
+        isSidebar
+          ? "bg-sidebar/80 supports-[backdrop-filter]:bg-sidebar/70"
+          : "rounded-2xl border border-foreground/10 bg-background/90 shadow-2xl backdrop-blur-xl",
+      )}
+    >
+      <div className="px-5 pb-5 pt-2">
+        <div className="flex items-start gap-3 border-b border-foreground/10 pb-4">
+          <div className="flex min-w-0 flex-1 gap-3">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center text-foreground/55">
+              <Plane className="h-6 w-6" aria-hidden="true" />
+            </div>
+            <div className="min-w-0 pt-0.5">
+              <h3 className="truncate text-lg font-semibold tracking-tight">
+                {identity}
+              </h3>
+              <p className="mt-0.5 font-mono text-[11px] uppercase tracking-wider text-foreground/50">
+                ICAO {flight.icao24}
+                {flightNumber ? `, flight ${flightNumber}` : ""}
+              </p>
+              {details.airline && (
+                <p className="mt-1 truncate text-xs text-foreground/70">
+                  Airline: {details.airline}
+                </p>
+              )}
+            </div>
+          </div>
+
+          {heroPhoto && (
+            <PhotoPreview
+              photo={heroPhoto}
+              label={details.registration ?? identity}
+            />
+          )}
+
+          {!isSidebar && (
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex h-8 w-8 shrink-0 items-center justify-center text-foreground/55 transition-colors hover:text-foreground"
+              aria-label="Close aircraft details"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+
+        <RouteSummary routeInfo={routeInfo} />
+
+        <dl className="grid grid-cols-2 border-b border-foreground/10 py-3">
+          {hasPosition(flight) && (
+            <PrimaryField
+              label="Position"
+              value={formatPosition(flight.latitude, flight.longitude)}
+            />
+          )}
+          {finiteValue(flight.baroAltitude) !== null && (
+            <PrimaryField
+              label="Altitude"
+              value={formatAltitude(flight.baroAltitude, unitSystem)}
+            />
+          )}
+          {finiteValue(flight.velocity) !== null && (
+            <PrimaryField
+              label="Speed"
+              value={formatSpeed(flight.velocity, unitSystem)}
+            />
+          )}
+          <PrimaryField label="Status" value={statusItems.join(", ")} />
+        </dl>
+
+        <div className="border-b border-foreground/10 py-3 text-xs text-foreground/65">
+          <p aria-live="off" aria-atomic="false">
+            {freshness}
+          </p>
+          {sources.length > 0 && (
+            <p className="mt-1">Sources: {sources.join(", ")}</p>
+          )}
+        </div>
+
+        <details
+          key={flight.icao24}
+          className="group border-b border-foreground/10"
+        >
+          <summary className="flex min-h-11 cursor-pointer list-none items-center justify-between py-3 text-sm font-medium marker:content-none">
+            Details
+            <ChevronDown className="h-4 w-4 text-foreground/45 transition-transform group-open:rotate-180" />
+          </summary>
+          <dl className="pb-3">
+            <DetailRow label="Registration" value={details.registration} />
+            <DetailRow
+              label="Registration country"
+              value={joinValues(
+                details.registrationCountryFlag,
+                details.registrationCountry,
+              )}
+            />
+            <DetailRow label="Manufacturer" value={details.manufacturer} />
+            <DetailRow label="Model" value={details.model} />
+            <DetailRow label="Type code" value={details.typeCode} />
+            <DetailRow
+              label="Heading"
+              value={
+                finiteValue(heading) !== null
+                  ? `${Math.round(heading ?? 0)}° ${cardinal}`
+                  : null
+              }
+            />
+            <DetailRow
+              label="Vertical speed"
+              value={
+                verticalRate !== null
+                  ? formatVerticalSpeed(verticalRate, unitSystem)
+                  : null
+              }
+            />
+            <DetailRow
+              label="GPS altitude"
+              value={
+                finiteValue(flight.geoAltitude) !== null
+                  ? formatAltitude(flight.geoAltitude, unitSystem)
+                  : null
+              }
+            />
+            <DetailRow
+              label="True airspeed"
+              value={
+                finiteValue(flight.tas) !== null
+                  ? formatSpeedFromKnots(flight.tas, unitSystem)
+                  : null
+              }
+            />
+            <DetailRow label="Squawk" value={cleanText(flight.squawk)} />
+            <DetailRow
+              label="Position method"
+              value={formatPositionMethod(flight.positionSource)}
+            />
+            {showDebugData && (
+              <>
+                <DetailRow
+                  label="NACp"
+                  value={formatNumber(flight.debugData?.nacP)}
+                />
+                <DetailRow
+                  label="NIC"
+                  value={formatNumber(flight.debugData?.nic)}
+                />
+                <DetailRow
+                  label="ADS-B version"
+                  value={formatNumber(flight.debugData?.version)}
+                />
+              </>
+            )}
+          </dl>
+        </details>
+
+        {onToggleFpv && (
+          <button
+            type="button"
+            onClick={() =>
+              (isFpvActive || canEnterFpv) && onToggleFpv(flight.icao24)
+            }
+            disabled={!isFpvActive && !canEnterFpv}
+            className="mt-3 flex min-h-10 w-full items-center gap-2 text-left text-sm font-medium text-foreground/70 transition-colors hover:text-foreground disabled:cursor-not-allowed disabled:opacity-35"
+            aria-label={
+              isFpvActive
+                ? "Exit first person view"
+                : canEnterFpv
+                  ? "Enter first person view"
+                  : "First person view unavailable"
+            }
+          >
+            <Eye className="h-4 w-4" aria-hidden="true" />
+            {isFpvActive ? "Exit first person view" : "First person view"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
 }
 
-function squawkLabel(squawk: string): string {
-  switch (squawk.trim()) {
-    case "7500":
-      return "Hijack";
-    case "7600":
-      return "Radio fail";
-    case "7700":
-      return "Emergency";
-    default:
-      return "";
-  }
+function PhotoPreview({
+  photo,
+  label,
+}: {
+  photo: NormalizedPhoto;
+  label: string;
+}) {
+  const image = (
+    <Image
+      src={photo.thumbnail || photo.url}
+      alt={`${label} aircraft`}
+      width={112}
+      height={80}
+      className="h-20 w-28 object-cover"
+      unoptimized
+    />
+  );
+
+  return (
+    <figure className="w-28 shrink-0 overflow-hidden rounded-lg">
+      {photo.link ? (
+        <a href={photo.link} target="_blank" rel="noreferrer">
+          {image}
+        </a>
+      ) : (
+        image
+      )}
+      {photo.photographer && (
+        <figcaption className="truncate pt-1 text-[9px] text-foreground/45">
+          Photo: {photo.photographer}
+        </figcaption>
+      )}
+    </figure>
+  );
+}
+
+function RouteSummary({ routeInfo }: { routeInfo: FlightRouteInfo }) {
+  if (!routeInfo.available) return null;
+
+  const origin = routeInfo.origin ? formatAirportCode(routeInfo.origin) : null;
+  const destination = routeInfo.destination
+    ? formatAirportCode(routeInfo.destination)
+    : null;
+
+  if (!origin || !destination) return null;
+
+  return (
+    <section className="border-b border-foreground/10 py-3">
+      <p className="text-[10px] font-semibold uppercase tracking-wider text-foreground/45">
+        Reported route
+      </p>
+      <p className="mt-1 text-base font-semibold tracking-tight">
+        {origin} <span aria-hidden="true">→</span> {destination}
+      </p>
+      {(routeInfo.origin?.municipality ||
+        routeInfo.destination?.municipality) && (
+        <p className="mt-1 truncate text-xs text-foreground/55">
+          {[routeInfo.origin?.municipality, routeInfo.destination?.municipality]
+            .filter(Boolean)
+            .join(" to ")}
+        </p>
+      )}
+    </section>
+  );
+}
+
+function PrimaryField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0 py-2 pr-3">
+      <dt className="text-[10px] font-semibold uppercase tracking-wider text-foreground/45">
+        {label}
+      </dt>
+      <dd className="mt-1 truncate text-sm font-medium tabular-nums text-foreground/90">
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+function DetailRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | null;
+}) {
+  if (!value) return null;
+
+  return (
+    <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)] gap-3 border-t border-foreground/[0.06] py-2 text-xs first:border-t-0">
+      <dt className="text-foreground/50">{label}</dt>
+      <dd className="min-w-0 text-right text-foreground/80">{value}</dd>
+    </div>
+  );
+}
+
+function useFreshness(updatedAt: number): string {
+  const [now, setNow] = useState(updatedAt);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), 1_000);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  return formatAircraftFreshness(updatedAt, now);
+}
+
+function hasPosition(
+  flight: FlightState,
+): flight is FlightState & { latitude: number; longitude: number } {
+  return (
+    finiteValue(flight.latitude) !== null &&
+    finiteValue(flight.longitude) !== null
+  );
+}
+
+function formatPosition(latitude: number, longitude: number): string {
+  const latitudeDirection = latitude >= 0 ? "N" : "S";
+  const longitudeDirection = longitude >= 0 ? "E" : "W";
+  return `${Math.abs(latitude).toFixed(2)}°${latitudeDirection}, ${Math.abs(longitude).toFixed(2)}°${longitudeDirection}`;
+}
+
+function formatPositionMethod(
+  source: FlightState["positionSource"],
+): string | null {
+  if (!source) return null;
+  if (source === "adsb") return "ADS-B";
+  return source.toUpperCase();
+}
+
+function finiteValue(value: number | null | undefined): number | null {
+  return value != null && Number.isFinite(value) ? value : null;
+}
+
+function cleanText(value: string | null | undefined): string | null {
+  const cleaned = value?.trim();
+  return cleaned ? cleaned : null;
+}
+
+function joinValues(
+  first: string | null,
+  second: string | null,
+): string | null {
+  const values = [first, second].filter(
+    (value): value is string => Boolean(value),
+  );
+  return values.length > 0 ? values.join(" ") : null;
+}
+
+function formatNumber(value: number | null | undefined): string | null {
+  return value != null && Number.isFinite(value) ? String(value) : null;
 }
 
 function isMilitary(dbFlags?: number | null): boolean {
@@ -612,168 +493,5 @@ function isMilitary(dbFlags?: number | null): boolean {
 }
 
 function isEmergencyStatus(status?: string | null): boolean {
-  return !!status && status !== "none";
-}
-
-function hasDebugData(data: FlightState["debugData"]): boolean {
-  return !!(
-    data &&
-    (data.nic != null ||
-      data.nacP != null ||
-      data.nacV != null ||
-      data.sil != null ||
-      data.version != null ||
-      (data.alert != null && data.alert !== 0) ||
-      data.messages != null ||
-      data.seen != null ||
-      data.rssi != null)
-  );
-}
-
-function IconCell({
-  children,
-  active = false,
-}: {
-  children: React.ReactNode;
-  active?: boolean;
-}) {
-  return (
-    <span
-      className={cn(
-        "flex h-7 w-7 shrink-0 items-center justify-center rounded-[10px] border border-foreground/[0.06] bg-background/45 text-foreground/36 shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]",
-        active &&
-          "border-emerald-300/20 bg-emerald-400/10 text-emerald-300/90",
-      )}
-    >
-      {children}
-    </span>
-  );
-}
-
-function GroupedRow({
-  icon,
-  children,
-  divided = false,
-}: {
-  icon: React.ReactNode;
-  children: React.ReactNode;
-  divided?: boolean;
-}) {
-  return (
-    <div
-      className={cn(
-        "flex min-h-11 items-center gap-3 px-3.5 py-2.5",
-        divided && "border-t border-foreground/[0.06]",
-      )}
-    >
-      <IconCell>{icon}</IconCell>
-      <div className="min-w-0 flex-1">{children}</div>
-    </div>
-  );
-}
-
-function Metric({
-  icon,
-  label,
-  value,
-  secondary,
-}: {
-  icon: React.ReactNode;
-  label: string;
-  value: string;
-  secondary?: string | null;
-}) {
-  return (
-    <div className="flex min-h-[78px] flex-col justify-between rounded-[18px] border border-foreground/[0.055] bg-background/35 px-3 py-2.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
-      <div className="flex items-center gap-1.5 text-foreground/38">
-        {icon}
-        <span className="text-[10px] font-semibold tracking-wide uppercase">
-          {label}
-        </span>
-      </div>
-      <p className="mt-2 text-[15px] font-semibold leading-none tabular-nums text-foreground/92">
-        {value}
-      </p>
-      {secondary ? (
-        <p className="mt-1 truncate text-[10px] font-medium text-foreground/42">
-          {secondary}
-        </p>
-      ) : null}
-    </div>
-  );
-}
-
-function RouteBanner({
-  routeInfo,
-  showSource = false,
-}: {
-  routeInfo: FlightRouteInfo;
-  showSource?: boolean;
-}) {
-  if (!routeInfo.available) return null;
-
-  const originCode = routeInfo.origin
-    ? formatAirportCode(routeInfo.origin)
-    : null;
-  const destCode = routeInfo.destination
-    ? formatAirportCode(routeInfo.destination)
-    : null;
-
-  if (!originCode && !destCode) return null;
-
-  return (
-    <div className="mt-4 rounded-[22px] border border-foreground/[0.07] bg-foreground/[0.035] px-4 py-3.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]">
-      <div className="flex items-center">
-        <div className="flex min-w-0 flex-1 flex-col">
-          {originCode ? (
-            <>
-              <span className="text-[17px] font-semibold tracking-tight text-foreground/92">
-                {originCode}
-              </span>
-              {routeInfo.origin?.municipality && (
-                <span className="mt-0.5 truncate text-[11px] font-medium text-foreground/42">
-                  {routeInfo.origin.municipality}
-                </span>
-              )}
-            </>
-          ) : (
-            <span className="text-xs text-foreground/20">-</span>
-          )}
-        </div>
-
-        <div className="mx-2 flex items-center gap-1.5">
-          <div className="h-px w-5 bg-foreground/12" />
-          <span className="flex h-7 w-7 items-center justify-center rounded-full bg-background/40 text-foreground/42 ring-1 ring-foreground/[0.06]">
-            <Plane className="h-3.5 w-3.5 shrink-0" />
-          </span>
-          <div className="h-px w-5 bg-foreground/12" />
-        </div>
-
-        <div className="flex min-w-0 flex-1 flex-col items-end text-right">
-          {destCode ? (
-            <>
-              <span className="text-[17px] font-semibold tracking-tight text-foreground/92">
-                {destCode}
-              </span>
-              {routeInfo.destination?.municipality && (
-                <span className="mt-0.5 truncate text-[11px] font-medium text-foreground/42">
-                  {routeInfo.destination.municipality}
-                </span>
-              )}
-            </>
-          ) : (
-            <span className="text-xs text-foreground/20">-</span>
-          )}
-        </div>
-      </div>
-
-      {showSource && routeInfo.source && (
-        <div className="mt-2 flex justify-center">
-          <span className="rounded-full border border-foreground/[0.06] bg-background/30 px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-foreground/35">
-            {routeInfo.source}
-          </span>
-        </div>
-      )}
-    </div>
-  );
+  return Boolean(status && status !== "none");
 }

--- a/src/components/ui/hero-banner.test.ts
+++ b/src/components/ui/hero-banner.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { HeroBanner, shouldRenderHeroBanner } from "./hero-banner";
+import type { NormalizedPhoto } from "@/hooks/use-aircraft-photos";
+
+const PHOTO: NormalizedPhoto = {
+  id: "photo-1",
+  url: "https://example.com/aircraft.jpg",
+  thumbnail: "https://example.com/aircraft-thumb.jpg",
+  photographer: "Test Photographer",
+  location: null,
+  dateTaken: null,
+  link: "https://example.com/photo-1",
+};
+
+test("HeroBanner renders the old hero height for a valid photo", () => {
+  const html = renderToStaticMarkup(
+    createElement(HeroBanner, {
+      photo: PHOTO,
+      loading: false,
+      alt: "JAL60 aircraft",
+    }),
+  );
+
+  assert.match(html, /h-52/);
+  assert.match(html, /sm:h-56/);
+  assert.match(html, /JAL60 aircraft/);
+  assert.match(html, /https:\/\/example\.com\/aircraft\.jpg/);
+});
+
+test("HeroBanner renders a full-height loading skeleton", () => {
+  const html = renderToStaticMarkup(
+    createElement(HeroBanner, {
+      photo: null,
+      loading: true,
+      alt: "Aircraft",
+    }),
+  );
+
+  assert.match(html, /h-52/);
+  assert.match(html, /animate-pulse/);
+  assert.doesNotMatch(html, /<img/);
+});
+
+test("HeroBanner collapses after an empty photo result", () => {
+  const html = renderToStaticMarkup(
+    createElement(HeroBanner, {
+      photo: null,
+      loading: false,
+      alt: "Aircraft",
+    }),
+  );
+
+  assert.equal(html, "");
+});
+
+test("HeroBanner collapses after all photo candidates fail", () => {
+  assert.equal(shouldRenderHeroBanner(PHOTO, false, true), false);
+  assert.equal(shouldRenderHeroBanner(PHOTO, false, false), true);
+});

--- a/src/components/ui/hero-banner.tsx
+++ b/src/components/ui/hero-banner.tsx
@@ -1,21 +1,21 @@
 "use client";
 
-import { useMemo, useState, useEffect } from "react";
+import { useMemo, useState } from "react";
+import { AnimatePresence, motion } from "motion/react";
 import { Camera } from "lucide-react";
 import type { NormalizedPhoto } from "@/hooks/use-aircraft-photos";
 
 type HeroBannerProps = {
   photo: NormalizedPhoto | null;
   loading: boolean;
+  alt: string;
 };
 
 export function HeroBanner({
   photo,
   loading,
+  alt,
 }: HeroBannerProps) {
-  const [loaded, setLoaded] = useState(false);
-  const [failed, setFailed] = useState(false);
-  const [sourceIndex, setSourceIndex] = useState(0);
   const candidates = useMemo(() => {
     const urls = [photo?.url, photo?.thumbnail]
       .map((url) => url?.trim())
@@ -23,60 +23,105 @@ export function HeroBanner({
 
     return Array.from(new Set(urls));
   }, [photo?.thumbnail, photo?.url]);
-  const source = candidates[sourceIndex] ?? null;
   const candidateKey = candidates.join("|");
-
-  useEffect(() => {
-    const timeout = window.setTimeout(() => {
-      setLoaded(false);
-      setFailed(false);
-      setSourceIndex(0);
-    }, 0);
-    return () => window.clearTimeout(timeout);
-  }, [photo?.id, candidateKey]);
+  const [imageState, setImageState] = useState({
+    key: candidateKey,
+    loaded: false,
+    failed: false,
+    sourceIndex: 0,
+  });
+  const activeImageState =
+    imageState.key === candidateKey
+      ? imageState
+      : {
+          key: candidateKey,
+          loaded: false,
+          failed: false,
+          sourceIndex: 0,
+        };
+  const { loaded, failed, sourceIndex } = activeImageState;
+  const source = candidates[sourceIndex] ?? null;
 
   const hasPhoto = source != null && !failed;
+  const visible = shouldRenderHeroBanner(photo, loading, failed);
 
   return (
-    <div className="relative h-52 w-full overflow-hidden bg-foreground/[0.04] sm:h-56">
-      {(loading || (hasPhoto && !loaded)) && (
-        <span
-          aria-hidden
-          className="absolute inset-0 animate-pulse bg-linear-to-br from-foreground/[0.04] via-foreground/[0.08] to-foreground/[0.04]"
-        />
-      )}
-
-      {source && !failed && (
-        <>
-          <img
-            key={source}
-            src={source}
-            alt="Aircraft"
-            loading="eager"
-            decoding="async"
-            referrerPolicy="no-referrer"
-            onLoad={() => setLoaded(true)}
-            onError={() => {
-              const nextIndex = sourceIndex + 1;
-              if (nextIndex < candidates.length) {
-                setLoaded(false);
-                setSourceIndex(nextIndex);
-                return;
-              }
-              setFailed(true);
-            }}
-            className={`absolute inset-0 h-full w-full object-cover transition-opacity duration-500 ease-[cubic-bezier(0.16,1,0.3,1)] ${loaded ? "opacity-100" : "opacity-0"}`}
-            draggable={false}
-          />
-          <span className="pointer-events-none absolute inset-0 bg-linear-to-t from-background/55 via-background/5 to-transparent" />
-          {photo?.photographer && loaded && (
-            <span className="absolute bottom-2 right-2.5 flex items-center gap-1 rounded-full border border-foreground/[0.06] bg-background/55 px-2.5 py-1 text-[9px] font-medium text-foreground/65 shadow-sm backdrop-blur-md">
-              <Camera className="h-2.5 w-2.5" />
-              {photo?.photographer}
-            </span>
+    <AnimatePresence initial={false}>
+      {visible && (
+        <motion.div
+          key="aircraft-hero"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ height: 0, opacity: 0 }}
+          transition={{ duration: 0.22, ease: [0.16, 1, 0.3, 1] }}
+          className="relative h-52 w-full overflow-hidden bg-foreground/[0.04] sm:h-56"
+        >
+          {(loading || (hasPhoto && !loaded)) && (
+            <span
+              aria-hidden
+              className="absolute inset-0 animate-pulse bg-linear-to-br from-foreground/[0.04] via-foreground/[0.08] to-foreground/[0.04]"
+            />
           )}
-        </>
+
+          {source && !failed && (
+            <>
+              {/* eslint-disable-next-line @next/next/no-img-element -- Photo sources can use external hosts that are not known at build time. */}
+              <img
+                key={source}
+                src={source}
+                alt={alt}
+                loading="eager"
+                decoding="async"
+                referrerPolicy="no-referrer"
+                onLoad={() =>
+                  setImageState((current) => ({
+                    ...current,
+                    key: candidateKey,
+                    loaded: true,
+                    failed: false,
+                    sourceIndex,
+                  }))
+                }
+                onError={() => {
+                  const nextIndex = sourceIndex + 1;
+                  if (nextIndex < candidates.length) {
+                    setImageState({
+                      key: candidateKey,
+                      loaded: false,
+                      failed: false,
+                      sourceIndex: nextIndex,
+                    });
+                    return;
+                  }
+                  setImageState({
+                    key: candidateKey,
+                    loaded: false,
+                    failed: true,
+                    sourceIndex,
+                  });
+                }}
+                className={`absolute inset-0 h-full w-full object-cover transition-opacity duration-500 ease-[cubic-bezier(0.16,1,0.3,1)] ${loaded ? "opacity-100" : "opacity-0"}`}
+                draggable={false}
+              />
+              <span className="pointer-events-none absolute inset-0 bg-linear-to-t from-background/55 via-background/5 to-transparent" />
+              {photo?.photographer && loaded && (
+                <span className="absolute bottom-2 right-2.5 flex items-center gap-1 rounded-full border border-foreground/[0.06] bg-background/55 px-2.5 py-1 text-[9px] font-medium text-foreground/65 shadow-sm backdrop-blur-md">
+                  <Camera className="h-2.5 w-2.5" aria-hidden="true" />
+                  Photo: {photo.photographer}
+                </span>
+              )}
+            </>
+          )}
+        </motion.div>
       )}
-    </div>
+    </AnimatePresence>
   );
+}
+
+export function shouldRenderHeroBanner(
+  photo: NormalizedPhoto | null,
+  loading: boolean,
+  failed: boolean,
+): boolean {
+  return loading || (photo !== null && !failed);
 }

--- a/src/components/ui/mobile-flight-toast.tsx
+++ b/src/components/ui/mobile-flight-toast.tsx
@@ -28,7 +28,6 @@ import {
   headingToCardinal,
 } from "@/lib/flight-utils";
 import { lookupAirline, parseFlightNumber } from "@/lib/airlines";
-import { aircraftTypeHint } from "@/lib/aircraft";
 import { airlineLogoCandidates } from "@/lib/airline-logos";
 import {
   loadedAirlineLogoUrls,
@@ -229,13 +228,8 @@ export function MobileFlightToast({
 }: MobileFlightToastProps) {
   const { settings } = useSettings();
   const airline = lookupAirline(flight.callsign);
-  const flightNum = parseFlightNumber(flight.callsign);
-  const company =
-    airline ??
-    (flight.registrationCountry
-      ? `${flight.registrationCountry} operator`
-      : null);
-  const model = aircraftTypeHint(flight.category);
+  const flightNum = airline ? parseFlightNumber(flight.callsign) : null;
+  const company = airline;
   const heading = flight.trueTrack;
   const cardinal = heading !== null ? headingToCardinal(heading) : null;
   const canEnterFpv =
@@ -249,7 +243,6 @@ export function MobileFlightToast({
   const [logoLoadedByKey, setLogoLoadedByKey] = useState<
     Record<string, boolean>
   >({});
-  const [genericLogoFailed, setGenericLogoFailed] = useState(false);
 
   const airlineKey = airline ?? "__none__";
   const baseLogoIndex = logoIndexByAirline[airlineKey] ?? 0;
@@ -270,7 +263,6 @@ export function MobileFlightToast({
     (logoUrl ? loadedAirlineLogoUrls.has(logoUrl) : false) ||
     (logoLoadedByKey[logoLoadKey] ?? false);
   const showLogo = Boolean(logoUrl);
-  const genericLogoUrl = "/airline-logos/envoy-air.png";
 
   // Aircraft photos and details.
   const {
@@ -338,22 +330,8 @@ export function MobileFlightToast({
                 />
               </span>
             ) : (
-              <span className="relative flex h-12 w-12 items-center justify-center overflow-hidden rounded-[14px] border border-black/5 bg-white/95 p-2.5 shadow-sm">
-                {genericLogoFailed ? (
-                  <span className="text-[16px] font-semibold text-background/25">
-                    -
-                  </span>
-                ) : (
-                  <Image
-                    src={genericLogoUrl}
-                    alt="Generic airline logo"
-                    width={40}
-                    height={40}
-                    className="h-9 w-9 object-contain grayscale opacity-80"
-                    unoptimized
-                    onError={() => setGenericLogoFailed(true)}
-                  />
-                )}
+              <span className="relative flex h-12 w-12 items-center justify-center overflow-hidden rounded-[14px] border border-foreground/10 bg-background/45 text-foreground/45 shadow-sm">
+                <Plane className="h-6 w-6" aria-hidden="true" />
               </span>
             )}
           </div>
@@ -378,7 +356,7 @@ export function MobileFlightToast({
             type="button"
             onClick={onClose}
             className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-foreground/[0.06] bg-foreground/[0.05] text-foreground/50 transition-colors active:bg-foreground/10"
-            aria-label="Close flight details"
+            aria-label="Close aircraft details"
           >
             <X className="h-3.5 w-3.5" />
           </button>
@@ -388,55 +366,38 @@ export function MobileFlightToast({
           {company && (
             <MobileGroupedRow icon={<Building2 className="h-3.5 w-3.5" />}>
               <p className="truncate text-[13px] font-medium text-foreground/74">
-                {company}
-                {flight?.typeDescription ? (
-                  <span className="text-foreground/40">
-                    {" "}
-                    · {flight.typeDescription}
-                  </span>
-                ) : model ? (
-                  <span className="text-foreground/40"> · {model}</span>
-                ) : null}
+                Airline: {company}
               </p>
             </MobileGroupedRow>
           )}
-          {/* Aircraft details (registration, type, owner) */}
-          {aircraftDetails &&
-            (aircraftDetails.registration ||
-              aircraftDetails.type ||
-              aircraftDetails.typeCode ||
-              aircraftDetails.owner) && (
+          {(flight.registration ||
+            aircraftDetails?.registration ||
+            flight.model ||
+            flight.typeDescription ||
+            aircraftDetails?.type ||
+            flight.typeCode ||
+            aircraftDetails?.typeCode ||
+            flight.manufacturer ||
+            aircraftDetails?.manufacturer) && (
               <MobileGroupedRow
                 icon={<Plane className="h-3.5 w-3.5" />}
                 divided={Boolean(company)}
               >
                 <p className="truncate text-[13px] text-foreground/58">
-                {[
-                  aircraftDetails.registration,
-                  aircraftDetails.type ?? aircraftDetails.typeCode,
-                  aircraftDetails.owner,
-                ]
-                  .filter(Boolean)
-                  .join(" · ")}
+                  {[
+                    flight.registration ?? aircraftDetails?.registration,
+                    flight.model ??
+                      flight.typeDescription ??
+                      aircraftDetails?.type ??
+                      flight.typeCode ??
+                      aircraftDetails?.typeCode,
+                    flight.manufacturer ?? aircraftDetails?.manufacturer,
+                  ]
+                    .filter(Boolean)
+                    .join(" · ")}
                 </p>
               </MobileGroupedRow>
             )}
-          {/* Registration fallback from flight data */}
-          {!aircraftDetails?.registration && flight?.registration && (
-            <MobileGroupedRow
-              icon={<Plane className="h-3.5 w-3.5" />}
-              divided={Boolean(company)}
-            >
-              <p className="truncate font-mono text-[13px] text-foreground/58">
-                {flight.registration}
-                {flight.typeCode && !flight.typeDescription ? (
-                  <span className="ml-1 text-foreground/30">
-                    [{flight.typeCode}]
-                  </span>
-                ) : null}
-              </p>
-            </MobileGroupedRow>
-          )}
         </div>
         {/* Military / Emergency indicators */}
         {(isMilitary(flight.dbFlags) ||
@@ -491,12 +452,14 @@ export function MobileFlightToast({
 
       {/* Info section: origin, heading + coords, squawk */}
       <div className="mx-4 mb-4 overflow-hidden rounded-[22px] border border-foreground/[0.07] bg-foreground/[0.035] shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]">
-        {/* Origin country */}
-        <MobileGroupedRow icon={<Globe className="h-3.5 w-3.5" />}>
-          <p className="text-[13px] text-foreground/65">
-            {flight.registrationCountry}
-          </p>
-        </MobileGroupedRow>
+        {/* Registration country */}
+        {flight.registrationCountry && (
+          <MobileGroupedRow icon={<Globe className="h-3.5 w-3.5" />}>
+            <p className="text-[13px] text-foreground/65">
+              Registration country: {flight.registrationCountry}
+            </p>
+          </MobileGroupedRow>
+        )}
 
         {/* Heading direction + coordinates */}
         {cardinal && (
@@ -512,7 +475,7 @@ export function MobileFlightToast({
                 }}
               />
             }
-            divided
+            divided={Boolean(flight.registrationCountry)}
           >
             <p className="text-[13px] text-foreground/65">
               Heading {cardinal}

--- a/src/lib/aircraft-sidebar.test.ts
+++ b/src/lib/aircraft-sidebar.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildAircraftSidebarViewModel,
+  formatAircraftDataSources,
+  formatAircraftFreshness,
+} from "./aircraft-sidebar";
+
+test("sidebar data does not infer an operator from a country", () => {
+  const view = buildAircraftSidebarViewModel(
+    {
+      manufacturer: null,
+      model: null,
+      registration: null,
+      registrationCountry: "United States",
+      registrationCountryFlag: "🇺🇸",
+      typeCode: null,
+      typeDescription: null,
+    },
+    null,
+    null,
+  );
+
+  assert.equal(view.airline, null);
+  assert.equal(view.registrationCountry, "United States");
+  assert.doesNotMatch(JSON.stringify(view), /operator/i);
+});
+
+test("sidebar data includes only supported identity fields", () => {
+  const view = buildAircraftSidebarViewModel(
+    {
+      manufacturer: "Boeing",
+      model: "737-832",
+      registration: "N3749D",
+      registrationCountry: "United States",
+      registrationCountryFlag: "🇺🇸",
+      typeCode: "B738",
+      typeDescription: null,
+    },
+    "Delta Air Lines",
+    {
+      manufacturer: "Unsupported fallback",
+      registration: "Unsupported fallback",
+      type: "Unsupported fallback",
+      typeCode: "Unsupported fallback",
+    },
+  );
+
+  assert.deepEqual(view, {
+    airline: "Delta Air Lines",
+    registration: "N3749D",
+    registrationCountry: "United States",
+    registrationCountryFlag: "🇺🇸",
+    manufacturer: "Boeing",
+    model: "737-832",
+    typeCode: "B738",
+  });
+});
+
+test("sidebar source and freshness text stays factual", () => {
+  assert.deepEqual(
+    formatAircraftDataSources(["adsb.lol", "faa", "adsb.lol"]),
+    ["adsb.lol", "FAA"],
+  );
+  assert.equal(
+    formatAircraftFreshness(1_000, 13_999),
+    "Updated 12 seconds ago",
+  );
+  assert.equal(
+    formatAircraftFreshness(1_000, 2_000),
+    "Updated 1 second ago",
+  );
+});

--- a/src/lib/aircraft-sidebar.ts
+++ b/src/lib/aircraft-sidebar.ts
@@ -1,0 +1,76 @@
+import type { AircraftDetails } from "@/hooks/use-aircraft-photos";
+import type { FlightState } from "@/lib/opensky";
+
+export type AircraftSidebarViewModel = {
+  airline: string | null;
+  registration: string | null;
+  registrationCountry: string | null;
+  registrationCountryFlag: string | null;
+  manufacturer: string | null;
+  model: string | null;
+  typeCode: string | null;
+};
+
+type SidebarFlightFields = Pick<
+  FlightState,
+  | "manufacturer"
+  | "model"
+  | "registration"
+  | "registrationCountry"
+  | "registrationCountryFlag"
+  | "typeCode"
+  | "typeDescription"
+>;
+
+type PhotoAircraftFields = Pick<
+  AircraftDetails,
+  "manufacturer" | "registration" | "type" | "typeCode"
+>;
+
+export function buildAircraftSidebarViewModel(
+  flight: SidebarFlightFields,
+  airline: string | null,
+  photoAircraft: PhotoAircraftFields | null,
+): AircraftSidebarViewModel {
+  return {
+    airline: cleanText(airline),
+    registration: cleanText(flight.registration ?? photoAircraft?.registration),
+    registrationCountry: cleanText(flight.registrationCountry),
+    registrationCountryFlag: cleanText(flight.registrationCountryFlag),
+    manufacturer: cleanText(
+      flight.manufacturer ?? photoAircraft?.manufacturer,
+    ),
+    model: cleanText(
+      flight.model ?? flight.typeDescription ?? photoAircraft?.type,
+    ),
+    typeCode: cleanText(flight.typeCode ?? photoAircraft?.typeCode),
+  };
+}
+
+export function formatAircraftDataSources(sources: string[]): string[] {
+  const labels = sources.map((source) => SOURCE_LABELS[source] ?? source);
+  return [...new Set(labels.filter(Boolean))];
+}
+
+export function formatAircraftFreshness(
+  updatedAt: number,
+  now: number,
+): string {
+  const ageSeconds = Math.max(0, Math.floor((now - updatedAt) / 1_000));
+  const unit = ageSeconds === 1 ? "second" : "seconds";
+  return `Updated ${ageSeconds} ${unit} ago`;
+}
+
+const SOURCE_LABELS: Record<string, string> = {
+  "adsb.fi": "adsb.fi",
+  "adsb.lol": "adsb.lol",
+  "airplanes.live": "Airplanes.live",
+  faa: "FAA",
+  mictronics: "Mictronics",
+  opensky: "OpenSky",
+};
+
+function cleanText(value: string | null | undefined): string | null {
+  const cleaned = value?.trim();
+  return cleaned ? cleaned : null;
+}

--- a/src/lib/release-metadata.test.ts
+++ b/src/lib/release-metadata.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import packageMetadata from "../../package.json";
+import { CHANGELOG } from "@/components/ui/control-panel-settings";
+
+test("top changelog version matches package metadata", () => {
+  const currentRelease = CHANGELOG[0];
+
+  assert.ok(currentRelease);
+  assert.equal(currentRelease.version, packageMetadata.version);
+  assert.deepEqual(
+    currentRelease.entries.map((entry) => entry.title),
+    [
+      "Open aviation data updates",
+      "Aircraft data and route trust",
+      "Simpler aircraft details",
+    ],
+  );
+});


### PR DESCRIPTION
## Summary

- Restore the 208 px and 224 px aircraft photo hero.
- Show a full-height loading skeleton, fade valid photos into place, and collapse the hero after an empty result or image failure.
- Restore the 64 px identity tile and prominent callsign.
- Use a shared airline logo only when the airline mapping supports it. Use a neutral aircraft icon otherwise.
- Keep one factual `Reported route` surface and hide invalid or conflicting routes.
- Keep position, altitude, speed, and status in one divided two-column surface.
- Keep secondary fields in one `Details` disclosure that resets when the selected aircraft changes.
- Hide unsupported fields, inferred operators, owners, generic logos, and placeholders.
- Keep dynamic source attribution and screen-reader-safe freshness text.
- Resize the desktop map to the visible area and keep its right edge fixed.
- Match the map and sidebar transitions at 640 ms.
- Use a smooth 32 px desktop seam radius.
- Center a newly selected aircraft without changing zoom, pitch, or bearing.
- Keep the last valid center while panels close or change. Do not recenter for repeated observations.
- Keep the mobile layout unchanged.

## Release metadata

- Version: `0.8.9`
- Release date: Aug 24, 2026
- Changelog topics: `Open aviation data updates`, `Aircraft data and route trust`, and `Simpler aircraft details`
- This PR contains the single consolidated `0.8.9` changelog entry.

## Stack

- Stack position: 3 of 3
- PR base: `data/flight-data-trust`
- Base commit: `e478aa236a84d4a22ff0245b4f82287ca0d013ff`
- Previous PR: #41

## Verification

- `pnpm test` with 351 passing tests
- `pnpm data:check` with 496,914 aircraft and 72,490 airports
- `pnpm lint` with no errors and four existing warnings
- `pnpm build`
- `git diff --check`
- No em dash characters in added lines, commit text, or PR text
- Chrome Work profile review in a separate group
- Dark and light review at 1440 by 900
- Mobile review at 390 by 844
- Photo, no-photo, valid-route, hidden-route, open Details, and panel transition checks
- Computed desktop seam radius confirmed at 32 px
- Screenshots saved outside the repository

## Production safety

- `main` is production.
- Keep this PR as a draft and unmerged for review.
- Do not enable auto-merge, publish a release, or deploy from this PR.
